### PR TITLE
Added option to export both types of Tau in tau.R

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '219273120'
+ValidationKey: '219464960'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "magpie4: MAgPIE outputs R package for MAgPIE version 4.x",
-  "version": "1.143.0",
+  "version": "1.144.0",
   "description": "<p>Common output routines for extracting results from the MAgPIE framework (versions 4.x).<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: magpie4
 Type: Package
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 1.143.0
+Version: 1.144.0
 Date: 2022-07-11
 Authors@R: c(person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = c("aut","cre")),
 		person("Florian", "Humpenoeder", email = "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/tau.R
+++ b/R/tau.R
@@ -10,7 +10,7 @@
 #' @param start_value If TRUE, the initial values are added under the year \code{prev_year}
 #' @param digits The result will be rounded to this number of digits
 #' @param prev_year Year to store the initialization tau information in
-#' @param type type of tc 'pastr' or 'crop'
+#' @param type type of tc 'pastr' or 'crop'; or "both" if both are needed
 #' @return A MAgPIE object containing tau values (index)
 #' @author Jan Philipp Dietrich
 #' @examples
@@ -19,9 +19,11 @@
 #' }
 #'
 tau <- function(gdx, file = NULL, level = "reg", start_value = FALSE, digits = 4, prev_year = "y1985", type = "crop") { #nolint
-  
+
   x <- readGDX(gdx, "ov_tau", format = "first_found")[, , "level"]
-  if(dim(x)[3] > 1){
+  if (dim(x)[3] > 1) {
+
+    ### If only "crop" Tau is desired
     if (type == "crop") {
       x <- x[, , "crop.level"]
       getNames(x) <- NULL
@@ -37,13 +39,13 @@ tau <- function(gdx, file = NULL, level = "reg", start_value = FALSE, digits = 4
         }
         x <- mbind(setYears(tau1995, prev_year), x)
       }
-      
+
       # bring superregional data back to regional level, if necessary
       supreg <- readGDX(gdx, "supreg", react = "silent")
       if (!is.null(supreg) && any(supreg$h != supreg$i)) {
         x <- toolAggregate(x, supreg)
       }
-      
+
       if (level != "reg") {
         cr <- croparea(gdx, level = "reg", water_aggr = TRUE)
         if (is.null(cr)) {
@@ -55,9 +57,10 @@ tau <- function(gdx, file = NULL, level = "reg", start_value = FALSE, digits = 4
         }
         x <- superAggregate(x, aggr_type = "weighted_mean", level = level, weight = cr)
       }
-      
+
     }
-    
+
+    ### if only "pastr" Tau is desired
     if (type == "pastr") {
       x <- x[, , "pastr.level"]
       getNames(x) <- NULL
@@ -66,35 +69,71 @@ tau <- function(gdx, file = NULL, level = "reg", start_value = FALSE, digits = 4
         return(NULL)
       }
       if (start_value) {
-        tau1995 <- readGDX(gdx, "fm_pastr_tau_hist", format = "first_found")[,1995,]
+        tau1995 <- readGDX(gdx, "fm_pastr_tau_hist", format = "first_found")[, 1995, ]
         if (is.null(x)) {
           warning("No Information on initial value for tau found in the gdx file! NULL is returned!")
           return(NULL)
         }
         x <- mbind(setYears(tau1995, prev_year), x)
       }
-      
+
       # bring superregional data back to regional level, if necessary
       supreg <- readGDX(gdx, "supreg", react = "silent")
       if (!is.null(supreg) && any(supreg$h != supreg$i)) {
         x <- toolAggregate(x, supreg)
       }
-      
+
       if (level != "reg") {
         pt <- NULL
-        pt <- readGDX(gdx, "ov31_grass_area", format = "first_found", react = "silent")[,,"pastr.level"]
+        pt <- readGDX(gdx, "ov31_grass_area", format = "first_found", react = "silent")[, , "pastr.level"]
         if (is.null(pt)) {
-          #warning("Grassland areas not disaggregated. Tau for managed pastures cannot be calculated. NULL returned")
+          warning("Grassland areas not disaggregated. Tau for managed pastures cannot be calculated. NULL returned")
           return(NULL)
         }
-        pt <- gdxAggregate(gdx,pt,to="reg",absolute = T)
+        pt <- gdxAggregate(gdx, pt, to="reg", absolute = T)
         if (start_value) {
           pt <- mbind(setYears(pt[, "y1995", ], prev_year), pt)
         }
         x <- superAggregate(x, aggr_type = "weighted_mean", level = level, weight = pt)
       }
     }
-    
+
+### For both "crop" and "pastr" Tau (running exo Tau with "grasslands_apr22" realiz of `31_past` module)
+    if (type == "both") {
+      if (is.null(x)) {
+        warning("No Information on tau in the gdx file! NULL is returned!")
+        return(NULL)
+      }
+      if (start_value) {
+        tau1995 <- readGDX(gdx, "f_tau1995", "fm_tau1995", format = "first_found")
+        if (is.null(x)) {
+          warning("No Information on initial value for tau found in the gdx file! NULL is returned!")
+          return(NULL)
+        }
+        x <- mbind(setYears(tau1995, prev_year), x)
+      }
+
+      # bring superregional data back to regional level, if necessary
+      supreg <- readGDX(gdx, "supreg", react = "silent")
+      if (!is.null(supreg) && any(supreg$h != supreg$i)) {
+        x <- toolAggregate(x, supreg)
+      }
+
+      if (level != "reg") {
+        cr <- croparea(gdx, level = "reg", water_aggr = TRUE)
+        if (is.null(cr)) {
+          warning("tau cannot be aggregated as croparea function returned NULL! NULL is returned!")
+          return(NULL)
+        }
+        if (start_value) {
+          cr <- mbind(setYears(cr[, "y1995", ], prev_year), cr)
+        }
+        x <- superAggregate(x, aggr_type = "weighted_mean", level = level, weight = cr)
+      }
+      x <- collapseNames(x) #Drop `.level` from dim 3 names
+    }
+
+  # account for default realization of `31_past` module with only "crop" Tau (no "pastr" Tau) where dim(x)[3] == 1
   } else {
     getNames(x) <- NULL
     if (is.null(x)) {
@@ -109,13 +148,13 @@ tau <- function(gdx, file = NULL, level = "reg", start_value = FALSE, digits = 4
       }
       x <- mbind(setYears(tau1995, prev_year), x)
     }
-    
+
     # bring superregional data back to regional level, if necessary
     supreg <- readGDX(gdx, "supreg", react = "silent")
     if (!is.null(supreg) && any(supreg$h != supreg$i)) {
       x <- toolAggregate(x, supreg)
     }
-    
+
     if (level != "reg") {
       cr <- croparea(gdx, level = "reg", water_aggr = TRUE)
       if (is.null(cr)) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **1.143.0**
+R package **magpie4**, version **1.144.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magpie4)](https://cran.r-project.org/package=magpie4) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Crawford M, Alves M (2022). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi: 10.5281/zenodo.1158582 (URL: https://doi.org/10.5281/zenodo.1158582), R package version 1.143.0, <URL: https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Crawford M, Alves M (2022). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi: 10.5281/zenodo.1158582 (URL: https://doi.org/10.5281/zenodo.1158582), R package version 1.144.0, <URL: https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Michael Crawford and Marcos Alves},
   year = {2022},
-  note = {R package version 1.143.0},
+  note = {R package version 1.144.0},
   doi = {10.5281/zenodo.1158582},
   url = {https://github.com/pik-piam/magpie4},
 }

--- a/man/tau.Rd
+++ b/man/tau.Rd
@@ -28,7 +28,7 @@ tau(
 
 \item{prev_year}{Year to store the initialization tau information in}
 
-\item{type}{type of tc 'pastr' or 'crop'}
+\item{type}{type of tc 'pastr' or 'crop'; or "both" if both are needed}
 }
 \value{
 A MAgPIE object containing tau values (index)


### PR DESCRIPTION
New version exports both "crop" and "pastr" Tau when argument `level = "both"`. This is needed when running exo Tau with the new `31_past` realization `grasslands_apr22`, 