### PR TITLE
Rewrite of reportEmissions.R

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '232797045'
+ValidationKey: '232906800'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 1.189.5
-date-released: '2023-08-02'
+version: 1.190.0
+date-released: '2023-08-03'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 1.189.5
-Date: 2023-08-02
+Version: 1.190.0
+Date: 2023-08-03
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/reportEmissions.R
+++ b/R/reportEmissions.R
@@ -4,14 +4,16 @@
 #' @export
 #'
 #' @param gdx GDX file
-#' @param storage_wood Accounting for long term carbon storage in wood products. Default is TRUE
-#' @return GHG emissions as MAgPIE object (Unit: Mt CO2/yr, Mt N2O/yr and Mt CH4/yr)
-#' @author Florian Humpenoeder, Benjamin Leon Bodirsky
+#' @param storageWood Accounting for long term carbon storage in wood products. Default is TRUE.
+#' @param grassi Replace MAgPIE's internal accounting of indirect emissions from land-use change with the estimates of Grassi et al.
+#' @return GHG emissions as MAgPIE object (Unit: Mt CO2/yr, Mt N2O/yr, and Mt CH4/yr, for cumulative emissions Gt CO2)
+#' @author Florian Humpenoeder, Benjamin Leon Bodirsky, Michael Crawford
 #' @examples
 #'
 #' \dontrun{
 #' x <- reportEmissions(gdx)
 #' }
+#' 
 #' @section Tier-1 variables:
 #' low pass filter = 3
 #' Name | Unit | Meta
@@ -29,546 +31,543 @@
 #' Emissions\|CO2\|Land\|+\|Land-use Change RAW | Mt CO2/yr | direct human-induced CO2 emissions from land use change, harvest and regrowth
 #' @md
 #'
-reportEmissions <- function(gdx, storage_wood = TRUE) {
+reportEmissions <- function(gdx, storageWood = TRUE, grassi = TRUE) {
+    
+    # -----------------------------------------------------------------------------------------------------------------
+    # Calculate CO2 emissions from a MAgPIE .gdx file
+    
+    # landuseChange is mostly positive (deforestation) and regrowth is mostly negative (regrowth/afforestation),
+    #   but there are some cases that behave differently.
+    
+    # landuseChange: cropland-to-pasture conversion causes negative emissions in soilc
+    
+    # regrowth: Litter carbon can decrease in case of afforestation/regrowth because the starting 
+    #   level of litter carbon is always pasture litc. If pasture litc is higher than natveg 
+    #   litc, this results in positive emissions.
+    .calcCO2 <- function(.lowpass = 3, .cumulative = FALSE, .raw = FALSE) {
+        
+        co2 <- emisCO2(gdx, 
+                       level = "regglo", unit = "gas", sum_land = FALSE, sum_cpool = FALSE, 
+                       lowpass = .lowpass, cumulative = .cumulative)
+        
+        # Replace indirect emissions from climate change on managed land with the Grassi coefficients?
+        if (grassi) {
+          climateChange <- landCarbonSink(gdx, level = "regglo", cumulative = .cumulative)
+        } else {
+          climateChange <- dimSums(co2[, , "cc"], dim = 3)
+        }
+        
+        # If cumulative, convert Mt CO2 to Gt CO2
+        if (.cumulative) {
+            co2 <- co2 / 1000 
+            climateChange <- climateChange / 1000
+        }  
 
-  # luc is mostly positive (deforestation), regrowth is mostly negative (regrowth/afforestation). There are, however, some cases that behave differently.
-  # luc: cropland-to-pasture conversion causes negative emissions in soilc
-  # regrowth: Litter carbon can decrease in case of afforestation/regrowth because the starting level of litter carbon is always pasture litc. If pasture litc is higher than natveg litc, this results in positive emissions.
-
-  a <- emisCO2(gdx, level = "regglo", unit = "gas", lowpass = 3, sum_land = F, sum_cpool = F)
-
-  #climatechange <- dimSums(a[, , "cc"], dim = 3)
-  climatechange <- landCarbonSink(gdx, level="regglo")
-  if(!is.null(climatechange)) getNames(climatechange) <- "Emissions|CO2|Land|+|Indirect (Mt CO2/yr)" # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
-  lu_tot <- dimSums(a[, , "lu"], dim = 3)
-  if(!is.null(climatechange)) {
-    total <- lu_tot + climatechange
-  } else {
-    total <- lu_tot
-  }
-  luc <- dimSums(a[, , "lu_luc"], dim = 3)
-  degrad <- dimSums(a[, , "lu_degrad"], dim = 3)
-  regrowth <- collapseNames(dimSums(a[, , "lu_regrowth"][, , c("forestry_plant", "forestry_ndc", "forestry_aff", "secdforest", "other")], dim = "c_pools"), collapsedim = "type")
-  emis_wood_products <- carbonLTS(gdx, level = "regglo", unit = "gas")[, getYears(total), ]
-
-
-  # Above Ground / Below Ground Carbon
-  #total_pools <- collapseNames(dimSums(a[, , "total"], dim = c("land")))
-  #climate_pools <- collapseNames(dimSums(a[, , "cc"], dim = c("land")))
-  lu_pools <- collapseNames(dimSums(a[, , "lu"], dim = c("land")))
-
-  ## Include degradation in gross emissions
-  luc <- luc + degrad
-
-  # wood products
-  if (!is.null(emis_wood_products) && storage_wood) {
-    # calc storage and decay
-    ## All categories
-    inflow <- collapseNames(emis_wood_products[, , "annual_inflow"])
-    outflow <- collapseNames(emis_wood_products[, , "annual_outflow"])
-    storage <- collapseNames(inflow + outflow)
-
-    ## Wood products (not including constr wood)
-    emis_wood <- collapseNames(emis_wood_products[, , "emis_wood"]) #-1 removed in carbonLTS_IPCC.R
-    emis_woodfuel <- collapseNames(emis_wood_products[, , "emis_woodfuel"]) #-1 removed in carbonLTS_IPCC.R
-    emis_constr_wood <- collapseNames(emis_wood_products[, , "emis_constr_wood"]) #-1 removed in carbonLTS_IPCC.R
-
-    ## purely industrial roundwood
-    emis_wood_inflow <- collapseNames(emis_wood_products[, , "wood_inflow"])
-    emis_wood_outflow <- collapseNames(emis_wood_products[, , "wood_outflow"])
-    emis_wood_net <- collapseNames(emis_wood_inflow + emis_wood_outflow) ## inflow is negative
-
-    ## Building materials
-    emis_building_inflow <- collapseNames(emis_wood_products[, , "building_inflow"])
-    emis_building_outflow <- collapseNames(emis_wood_products[, , "building_outflow"])
-    emis_building_net <- collapseNames(emis_building_inflow + emis_building_outflow) ## inflow is negative
-
-    # sum of net emissions from industrial roundwood and building material
-    storage <- emis_wood_net + emis_building_net
-    # total emissions from wood harvest
-    wood <- emis_woodfuel + storage  # emis_wood is already accounted for in storage!
-
-    # recalculate top categories
-    luc <- luc - (emis_wood + emis_woodfuel + emis_constr_wood) #take away all wood-related emissions
-    lu_tot <- luc + dimSums(regrowth, dim = 3) + wood #add wood-related emissions and removals
-    if(!is.null(climatechange)) {
-      total <- lu_tot + climatechange
-    } else {
-      total <- lu_tot
+        landuseTotal <- dimSums(co2[, , "lu"], dim = 3)
+        total <- landuseTotal + climateChange
+        
+        if (!.raw) {
+            
+            landuseChange <- dimSums(co2[, , "lu_luc"], dim = 3)
+            degradation   <- dimSums(co2[, , "lu_degrad"], dim = 3)
+            landuseChange <- landuseChange + degradation # Include degradation into gross emissions
+            
+            vegetation <- c("forestry_plant", "forestry_ndc", "forestry_aff", "secdforest", "other")
+            regrowth   <- collapseNames(dimSums(co2[, , "lu_regrowth"][, , vegetation], dim = "c_pools"), collapsedim = "type")
+            
+            # Above Ground / Below Ground Carbon
+            totalPools   <- collapseNames(dimSums(co2[, , "total"], dim = c("land")))
+            climatePools <- collapseNames(dimSums(co2[, , "cc"],    dim = c("land")))
+            landusePools <- collapseNames(dimSums(co2[, , "lu"],    dim = c("land")))
+            
+            # Calculate wood products, if forestry module was activated and desired
+            emisWoodProducts <- carbonLTS(gdx, level = "regglo", unit = "gas", cumulative = .cumulative)[, getYears(total), ]
+            
+            if (!is.null(emisWoodProducts) && storageWood) {
+                
+                if (.cumulative) {
+                    # Can't divide by 1000 during cumulative calc as in def runs its NULL and NULL/1000 is numeric(0)
+                    emisWoodProducts <- emisWoodProducts / 1000
+                }
+                
+                # All categories
+                inflow  <- collapseNames(emisWoodProducts[, , "annual_inflow"])
+                outflow <- collapseNames(emisWoodProducts[, , "annual_outflow"])
+                storage <- collapseNames(inflow + outflow)
+                
+                # Wood products (not including constr wood)
+                emisWood        <- collapseNames(emisWoodProducts[, , "emisWood"])       # -1 removed in carbonLTS_IPCC.R
+                emisWoodFuel    <- collapseNames(emisWoodProducts[, , "emisWoodFuel"])   # -1 removed in carbonLTS_IPCC.R
+                emisConstrWood  <- collapseNames(emisWoodProducts[, , "emisConstrWood"]) # -1 removed in carbonLTS_IPCC.R
+                
+                # Purely industrial roundwood
+                emisWoodInflow  <- collapseNames(emisWoodProducts[, , "wood_inflow"])
+                emisWoodOutflow <- collapseNames(emisWoodProducts[, , "wood_outflow"])
+                emisWoodNet     <- collapseNames(emisWoodInflow + emisWoodOutflow) # inflow is negative
+                
+                # Building materials
+                emisBuildingInflow  <- collapseNames(emisWoodProducts[, , "building_inflow"])
+                emisBuildingOutflow <- collapseNames(emisWoodProducts[, , "building_outflow"])
+                emisBuildingNet     <- collapseNames(emisBuildingInflow + emisBuildingOutflow) # inflow is negative
+                
+                ### NOTE TO FLORIAN -- STORAGE IS OVERWRITTEN HERE
+                # Sum of net emissions from industrial roundwood and building material
+                storage <- emisWoodNet + emisBuildingNet
+                
+                # Total emissions from wood harvest
+                wood <- emisWoodFuel + storage  # emisWood is already accounted for in storage!
+                
+                # Recalculate top-level categories
+                landuseChange <- landuseChange - (emisWood + emisWoodFuel + emisConstrWood) # Subtract all wood-related emissions
+                landuseTotal  <- landuseChange + dimSums(regrowth, dim = 3) + wood # Add wood-related emissions and removals
+                total <- landuseTotal + climateChange
+                
+                # Consistency check
+                if (abs(sum(landuseTotal - 
+                            (landuseChange + dimSums(regrowth, dim = 3) + collapseNames(wood)), 
+                            na.rm = TRUE)) > 0.1) {
+                    warning("Emission subcategories do not add up to total! Check the code.")
+                }
+                
+            } else {
+                
+                wood                <- NULL
+                emisWoodFuel        <- NULL
+                storage             <- NULL
+                inflow              <- NULL
+                outflow             <- NULL
+                emisWoodNet         <- NULL
+                emisWoodInflow      <- NULL
+                emisWoodOutflow     <- NULL
+                emisBuildingNet     <- NULL
+                emisBuildingInflow  <- NULL
+                emisBuildingOutflow <- NULL
+                
+            }
+        }
+        
+        # Never apply lowpass filter on peatland emissions
+        peatland <- PeatlandEmissions(gdx, level = "regglo", unit = "gas", cumulative = .cumulative)
+        if (!is.null(peatland)) {
+            peatland <- collapseNames(peatland[, , "co2"])
+            if (.cumulative) {
+                peatland <- peatland / 1000
+            }
+            
+            total        <- total + peatland
+            landuseTotal <- landuseTotal + peatland
+        }
+        
+        # Generate return list
+        if (.raw) {
+            .x <- list(
+                total         = total,
+                landuseTotal  = landuseTotal,
+                climateChange = climateChange
+            )
+            
+        } else {
+            .x <- list(
+                total                      = total, 
+                landuseTotal               = landuseTotal, 
+                climateChange              = climateChange, 
+                landuseChange              = landuseChange,
+                degradation                = degradation, 
+                totalRegrowth              = dimSums(regrowth, dim = 3),
+                regrowthAffCO2Price        = collapseNames(regrowth[, , "forestry_aff"]),
+                regrowthAffNPI_NDC         = collapseNames(regrowth[, , "forestry_ndc"]),
+                regrowthPlantations        = collapseNames(regrowth[, , "forestry_plant"]),
+                regrowthSecondaryForests   = collapseNames(regrowth[, , "secdforest"]),
+                regrowthOther              = collapseNames(regrowth[, , "other"]),
+                wood                       = wood,
+                emisWoodFuel               = emisWoodFuel,
+                storage                    = storage,
+                # inflow                    = inflow,
+                # outlow                    = outflow,
+                emisWoodNet                = emisWoodNet,
+                emisWoodInflow             = emisWoodInflow,
+                emisWoodOutflow            = emisWoodOutflow,
+                emisBuildingNet            = emisBuildingNet,
+                emisBuildingInflow         = emisBuildingInflow,
+                emisBuildingOutflow        = emisBuildingOutflow, 
+                peatland                   = peatland,
+                totalPools                 = totalPools,
+                climatePools               = climatePools,
+                landusePools               = landusePools
+            )
+        }
+        
+        return(.x)
     }
-
-    # check
-    #if (abs(sum(total - (lu_tot + climatechange), na.rm = TRUE)) > 0.1) warning("Emission subcategories do not add up to total! Check the code.")
-    if (abs(sum(lu_tot - (luc + dimSums(regrowth, dim = 3) + collapseNames(wood)), na.rm = TRUE)) > 0.1) warning("Emission subcategories do not add up to total! Check the code.")
-    # assign proper names
-
-    getNames(wood)                  <- "Emissions|CO2|Land|Land-use Change|+|Wood Harvest (Mt CO2/yr)"
-    getNames(emis_woodfuel)         <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Short Lived Products (Mt CO2/yr)"
-    getNames(storage)               <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage (Mt CO2/yr)" # carbon stored in wood products + release from wood products
-    # getNames(inflow)                <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Inflow (Mt CO2/yr)" # carbon stored in wood products
-    # getNames(outflow)               <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Outflow (Mt CO2/yr)" # slow release from wood products
-    getNames(emis_wood_net)         <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Industrial roundwood (Mt CO2/yr)" # carbon stored in Industrial roundwood + release from Industrial roundwood
-    getNames(emis_wood_inflow)      <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Inflow (Mt CO2/yr)" # carbon stored in Industrial roundwood
-    getNames(emis_wood_outflow)     <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Outflow (Mt CO2/yr)" # slow release from Industrial roundwood
-    getNames(emis_building_net)     <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Buildings (Mt CO2/yr)" # carbon stored in wood buildings + release from wood buildings
-    getNames(emis_building_inflow)  <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Mt CO2/yr)" # carbon stored in wood buildings
-    getNames(emis_building_outflow) <- "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Mt CO2/yr)" # slow release from wood buildings
-  } else {
-    wood <- emis_woodfuel <- storage <- inflow <- outflow <- emis_wood_net <- emis_wood_inflow <- emis_wood_outflow <- emis_building_net <- emis_building_inflow <- emis_building_outflow <- NULL
-  }
-
-  # Don't apply lowpass filter on peatland emissions
-  peatland <- PeatlandEmissions(gdx, level = "regglo", unit = "gas")
-  if (!is.null(peatland)) {
-    peatland <- collapseNames(peatland[, , "co2"])
-    total <- total + peatland
-    lu_tot <- lu_tot + peatland
-    getNames(peatland) <- "Emissions|CO2|Land|Land-use Change|+|Peatland (Mt CO2/yr)"
-  }
-
-  x <- mbind(
-    setNames(total, "Emissions|CO2|Land (Mt CO2/yr)"), # All human-induced land-related CO2 emissions
-    setNames(lu_tot, "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
-    peatland,
-    setNames(luc, "Emissions|CO2|Land|Land-use Change|+|Gross LUC (Mt CO2/yr)"), # land-use change
-    setNames(degrad, "Emissions|CO2|Land|Land-use Change|Gross LUC|+|Forest Degradation (Mt CO2/yr)"), # Forest Degradation
-    setNames(dimSums(regrowth, dim = 3), "Emissions|CO2|Land|Land-use Change|+|Regrowth (Mt CO2/yr)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "forestry_aff"]), "Emissions|CO2|Land|Land-use Change|Regrowth|CO2-price AR (Mt CO2/yr)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "forestry_ndc"]), "Emissions|CO2|Land|Land-use Change|Regrowth|NPI_NDC AR (Mt CO2/yr)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "forestry_plant"]), "Emissions|CO2|Land|Land-use Change|Regrowth|Timber Plantations (Mt CO2/yr)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "secdforest"]), "Emissions|CO2|Land|Land-use Change|Regrowth|Secondary Forest (Mt CO2/yr)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "other"]), "Emissions|CO2|Land|Land-use Change|Regrowth|Other Land (Mt CO2/yr)"), # regrowth of vegetation
-    wood,
-    emis_woodfuel,
-    storage,
-#    inflow,
-#    outflow,
-    emis_wood_net,
-    emis_wood_inflow,
-    emis_wood_outflow,
-    emis_building_net,
-    emis_building_inflow,
-    emis_building_outflow,
-    climatechange,
-    #setNames(total_pools, paste0("Emissions|CO2|Land|++|", getNames(total_pools), " (Mt CO2/yr)")),
-    setNames(lu_pools, paste0("Emissions|CO2|Land|Land-use Change|++|", getNames(lu_pools), " (Mt CO2/yr)"))
-    #setNames(climate_pools, paste0("Emissions|CO2|Land|Indirect|++|", getNames(climate_pools), " (Mt CO2/yr)"))
-  )
-
-  # CO2 annual lowpass=0
-  a <- emisCO2(gdx, level = "regglo", unit = "gas", lowpass = 0, sum_land = F, sum_cpool = F)
-
-  #climatechange <- dimSums(a[, , "cc"], dim = 3)
-  climatechange <- landCarbonSink(gdx, level="regglo")
-  if(!is.null(climatechange)) getNames(climatechange) <- "Emissions|CO2|Land RAW|+|Indirect RAW (Mt CO2/yr)" # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
-  lu_tot <- dimSums(a[, , "lu"], dim = 3)
-  if(!is.null(climatechange)) {
-    total <- lu_tot + climatechange
-  } else {
-    total <- lu_tot
-  }
-
-  peatland <- PeatlandEmissions(gdx, level = "regglo", unit = "gas")
-  if (!is.null(peatland)) {
-    peatland <- collapseNames(peatland[, , "co2"])
-    total <- total + peatland
-    lu_tot <- lu_tot + peatland
-  }
-
-  x <- mbind(
-    x, setNames(total, "Emissions|CO2|Land RAW (Mt CO2/yr)"), # All human-induced land-related CO2 emissions
-    setNames(lu_tot, "Emissions|CO2|Land RAW|+|Land-use Change RAW (Mt CO2/yr)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
-    climatechange
-  )
-
-  # CO2 cumulative lowpass=3
-  a <- emisCO2(gdx, level = "regglo", unit = "gas", lowpass = 3, sum_land = F, sum_cpool = F, cumulative = TRUE) / 1000
-
-  #climatechange <- dimSums(a[, , "cc"], dim = 3)
-  climatechange <- landCarbonSink(gdx, level="regglo", cumulative = TRUE)
-  if(!is.null(climatechange)) {
-    climatechange <- climatechange / 1000
-    getNames(climatechange) <- "Emissions|CO2|Land|Cumulative|+|Indirect (Gt CO2)" # indirect human-induced emissions: environmental change, climate change, natural effects
-  }
-  lu_tot <- dimSums(a[, , "lu"], dim = 3)
-  if(!is.null(climatechange)) {
-    total <- lu_tot + climatechange
-  } else {
-    total <- lu_tot
-  }
-  luc <- dimSums(a[, , "lu_luc"], dim = 3)
-  degrad <- dimSums(a[, , "lu_degrad"], dim = 3)
-  regrowth <- collapseNames(dimSums(a[, , "lu_regrowth"][, , c("forestry_plant", "forestry_ndc", "forestry_aff", "secdforest", "other")], dim = "c_pools"), collapsedim = "type")
-  emis_wood_products <- carbonLTS(gdx, level = "regglo", unit = "gas", cumulative = TRUE)[, getYears(total), ]
-
-  ## Include degradation in gross emissions
-  luc <- luc + degrad
-
-  # wood products
-  if (!is.null(emis_wood_products) && storage_wood) {
-    emis_wood_products <- emis_wood_products / 1000 ## Can't divide by 1000 during cumulative calc as in def runs its NULL and NULL/1000 is numeric(0)
-    # calc storage and decay
-    ## All categories
-    inflow <- collapseNames(emis_wood_products[, , "annual_inflow"])
-    outflow <- collapseNames(emis_wood_products[, , "annual_outflow"])
-    storage <- collapseNames(inflow + outflow)
-
-    ## Wood products (not including constr wood)
-    emis_wood <- collapseNames(emis_wood_products[, , "emis_wood"]) #-1 removed in carbonLTS_IPCC.R
-    emis_woodfuel <- collapseNames(emis_wood_products[, , "emis_woodfuel"]) #-1 removed in carbonLTS_IPCC.R
-    emis_constr_wood <- collapseNames(emis_wood_products[, , "emis_constr_wood"]) #-1 removed in carbonLTS_IPCC.R
-
-    ## What did we emit by burning and what did we save in storage
-    wood <- emis_woodfuel + storage  # emis_wood is already accounted for in storage!
-
-    ## purely industrial roundwood
-    emis_wood_inflow <- collapseNames(emis_wood_products[, , "wood_inflow"])
-    emis_wood_outflow <- collapseNames(emis_wood_products[, , "wood_outflow"])
-    emis_wood_net <- collapseNames(emis_wood_inflow + emis_wood_outflow) ## inflow is negative
-
-    ## Building materials
-    emis_building_inflow <- collapseNames(emis_wood_products[, , "building_inflow"])
-    emis_building_outflow <- collapseNames(emis_wood_products[, , "building_outflow"])
-    emis_building_net <- collapseNames(emis_building_inflow + emis_building_outflow) ## inflow is negative
-
-    # sum of net emissions from industrial roundwood and building material
-    storage <- emis_wood_net + emis_building_net
-    # total emissions from wood harvest
-    wood <- emis_woodfuel + storage  # emis_wood is already accounted for in storage!
-
-    # recalculate top categories
-    luc <- luc - (emis_wood + emis_woodfuel + emis_constr_wood) #take away all wood-related emissions
-    lu_tot <- luc + dimSums(regrowth, dim = 3) + wood #add wood-related emissions and removals
-    if(!is.null(climatechange)) {
-      total <- lu_tot + climatechange
-    } else {
-      total <- lu_tot
-    }
-
-    # check
-    #if (abs(sum(total - (lu_tot + climatechange), na.rm = TRUE)) > 0.1) warning("Emission subcategories do not add up to total! Check the code.")
-    if (abs(sum(lu_tot - (luc + dimSums(regrowth, dim = 3) + collapseNames(wood)), na.rm = TRUE)) > 0.1) warning("Emission subcategories do not add up to total! Check the code.")
-
-    # assign proper names
-    getNames(wood)                  <- "Emissions|CO2|Land|Cumulative|Land-use Change|+|Wood Harvest (Gt CO2)"
-    getNames(emis_woodfuel)         <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Short Lived Products (Gt CO2)"
-    getNames(storage)               <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage (Gt CO2)" # carbon stored in wood products + release from wood products
-    # getNames(inflow)                <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Inflow (Gt CO2)" # carbon stored in wood products
-    # getNames(outflow)               <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Outflow (Gt CO2)" # slow release from wood products
-    getNames(emis_wood_net)         <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|+|Industrial roundwood (Gt CO2)" # carbon stored in Industrial roundwood + release from Industrial roundwood
-    getNames(emis_wood_inflow)      <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Inflow (Gt CO2)" # carbon stored in Industrial roundwood
-    getNames(emis_wood_outflow)     <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Outflow (Gt CO2)" # slow release from Industrial roundwood
-    getNames(emis_building_net)     <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|+|Buildings (Gt CO2)" # carbon stored in wood buildings + release from wood buildings
-    getNames(emis_building_inflow)  <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Gt CO2)" # carbon stored in wood buildings
-    getNames(emis_building_outflow) <- "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Gt CO2)" # slow release from wood buildings
-  } else {
-    wood <- emis_woodfuel <- storage <- inflow <- outflow <- emis_wood_net <- emis_wood_inflow <- emis_wood_outflow <- emis_building_net <- emis_building_inflow <- emis_building_outflow <- NULL
-  }
-
-  # Don't apply lowpass filter on peatland emissions
-  peatland <- PeatlandEmissions(gdx, level = "regglo", unit = "gas", cumulative = TRUE)
-  if (!is.null(peatland)) {
-    peatland <- collapseNames(peatland[, , "co2"]) / 1000
-    total <- total + peatland
-    lu_tot <- lu_tot + peatland
-    getNames(peatland) <- "Emissions|CO2|Land|Cumulative|Land-use Change|+|Peatland (Gt CO2)"
-  }
-
-  x <- mbind(
-    x, setNames(total, "Emissions|CO2|Land|Cumulative (Gt CO2)"),
-    setNames(lu_tot, "Emissions|CO2|Land|Cumulative|+|Land-use Change (Gt CO2)"), # includes land-use change and regrowth of vegetation
-    peatland,
-    setNames(luc, "Emissions|CO2|Land|Cumulative|Land-use Change|+|Gross LUC (Gt CO2)"), # land-use change
-    setNames(degrad, "Emissions|CO2|Land|Cumulative|Land-use Change|Gross LUC|+|Forest Degradation (Mt CO2/yr)"), # Forest Degradation
-    setNames(dimSums(regrowth, dim = 3), "Emissions|CO2|Land|Cumulative|Land-use Change|+|Regrowth (Gt CO2)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "forestry_aff"]), "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|CO2-price AR (Gt CO2)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "forestry_ndc"]), "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|NPI_NDC AR (Gt CO2)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "forestry_plant"]), "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|Timber Plantations (Gt CO2)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "secdforest"]), "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|Secondary Forest (Gt CO2)"), # regrowth of vegetation
-    setNames(collapseNames(regrowth[, , "other"]), "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|Other Land (Gt CO2)"), # regrowth of vegetation
-    wood,
-    emis_woodfuel,
-    storage,
-#    inflow,
-#    outflow,
-    emis_wood_net,
-    emis_wood_inflow,
-    emis_wood_outflow,
-    emis_building_net,
-    emis_building_inflow,
-    emis_building_outflow,
-    climatechange
-  )
-
-  #x <- superAggregateX(x, level = "regglo", aggr_type = "sum")
-
-  # N2O, NOx, NH3
-  n_emissions <- c("n2o_n", "nh3_n", "no2_n", "no3_n", "n2o_n_direct", "n2o_n_indirect")
-  total <- Emissions(gdx, level = "regglo", type = n_emissions, unit = "gas", subcategories = TRUE, inorg_fert_split = TRUE)
-
-  #Add peatland emissions if missing
-  if(!"peatland" %in% getNames(total,dim=1)) {
-    peatland <- PeatlandEmissions(gdx, unit = "gas", level = "regglo")
-    if (!is.null(peatland)) {
-      peatland <- collapseNames(peatland[, , "n2o"])
-      getNames(peatland) <- "peatland.n2o"
-    } else {
-      peatland <- NULL
-    }
-    total <- mbind(total, peatland)
-  }
-
-
-  for (emi in getNames(total, dim = 2)) {
-    prefix <- paste0("Emissions|", reportingnames(emi), "|Land")
-    a <- total[, , emi]
-
-    emi2 <- emi
-    if (emi2 %in% c("n2o_direct", "n2o_indirect")) {
-      emi2 <- "n2o"
-    }
-    emi2 <- reportingnames(emi2)
-
-    agricult <- c("SOM", "inorg_fert", "man_crop", "awms", "resid", "man_past", "rice")
-    burn <- "resid_burn"
-    if (emi == "n2o") peatland <- "peatland" else peatland <- NULL
-
-    #subset, aggregate, rename and combine
-    x <- mbind(
-      x,
-      setNames(
-        dimSums(a[, , c(agricult,burn,peatland)], dim = 3),
-        paste0(prefix, " (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , agricult], dim = 3),
-        paste0(prefix, "|+|Agriculture (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , "awms"], dim = 3),
-        paste0(prefix, "|Agriculture|+|Animal Waste Management (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , c("inorg_fert", "man_crop", "resid", "SOM", "rice", "man_past")], dim = 3),
-        paste0(prefix, "|Agriculture|+|Agricultural Soils (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , c("inorg_fert", "rice")], dim = 3),
-        paste0(prefix, "|Agriculture|Agricultural Soils|+|Inorganic Fertilizers (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , c("inorg_fert_crop", "rice")], dim = 3),
-        paste0(prefix, "|Agriculture|Agricultural Soils|Inorganic Fertilizers|+|Cropland (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , c("inorg_fert_past")], dim = 3),
-        paste0(prefix, "|Agriculture|Agricultural Soils|Inorganic Fertilizers|+|Pasture (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , c("man_crop")], dim = 3),
-        paste0(prefix, "|Agriculture|Agricultural Soils|+|Manure applied to Croplands (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , c("resid")], dim = 3),
-        paste0(prefix, "|Agriculture|Agricultural Soils|+|Decay of Crop Residues (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , c("SOM")], dim = 3),
-        paste0(prefix, "|Agriculture|Agricultural Soils|+|Soil Organic Matter Loss (Mt ", emi2, "/yr)")
-      ),
-      #               setNames(dimSums(a[,,c("rice")],dim=3),
-      #                     paste0(prefix,"|Agriculture|Agricultural Soils|+|Lower N2O emissions of rice (Mt ",emi2,"/yr)")),
-      setNames(
-        dimSums(a[, , c("man_past")], dim = 3),
-        paste0(prefix, "|Agriculture|Agricultural Soils|+|Pasture (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , c(burn)], dim = 3),
-        paste0(prefix, "|+|Biomass Burning (Mt ", emi2, "/yr)")
-      ),
-      setNames(
-        dimSums(a[, , c("resid_burn")], dim = 3),
-        paste0(prefix, "|Biomass Burning|+|Burning of Crop Residues (Mt ", emi2, "/yr)")
+    
+    
+    # -----------------------------------------------------------------------------------------------------------------
+    # Yearly CO2 emissions, lowpass = 3
+    
+    yearlyCO2 <- .calcCO2(.lowpass = 3, .cumulative = FALSE)
+    
+    # nolint
+    emissionsReport <- with(yearlyCO2, 
+      mbind(
+        setNames(total,                     "Emissions|CO2|Land (Mt CO2/yr)"), # All human-induced land-related CO2 emissions
+        setNames(landuseTotal,              "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
+        setNames(climateChange,             "Emissions|CO2|Land|+|Indirect (Mt CO2/yr)"), # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
+        setNames(landuseChange,             "Emissions|CO2|Land|Land-use Change|+|Gross LUC (Mt CO2/yr)"), # land-use change
+        setNames(degradation,               "Emissions|CO2|Land|Land-use Change|Gross LUC|+|Forest Degradation (Mt CO2/yr)"), # forest Degradation
+        setNames(totalRegrowth,             "Emissions|CO2|Land|Land-use Change|+|Regrowth (Mt CO2/yr)"), # regrowth of vegetation
+        setNames(regrowthAffCO2Price,       "Emissions|CO2|Land|Land-use Change|Regrowth|CO2-price AR (Mt CO2/yr)"), # regrowth of vegetation
+        setNames(regrowthAffNPI_NDC,        "Emissions|CO2|Land|Land-use Change|Regrowth|NPI_NDC AR (Mt CO2/yr)"), # regrowth of vegetation
+        setNames(regrowthPlantations,       "Emissions|CO2|Land|Land-use Change|Regrowth|Timber Plantations (Mt CO2/yr)"), # regrowth of vegetation
+        setNames(regrowthSecondaryForests,  "Emissions|CO2|Land|Land-use Change|Regrowth|Secondary Forest (Mt CO2/yr)"), # regrowth of vegetation
+        setNames(regrowthOther,             "Emissions|CO2|Land|Land-use Change|Regrowth|Other Land (Mt CO2/yr)"), # regrowth of vegetation
+        setNames(peatland,                  "Emissions|CO2|Land|Land-use Change|+|Peatland (Mt CO2/yr)"),
+        # setNames(totalPools,                paste0("Emissions|CO2|Land|Land-use Change|++|", getNames(totalPools), " (Mt CO2/yr)")),
+        setNames(landusePools,              paste0("Emissions|CO2|Land|Land-use Change|++|", getNames(landusePools), " (Mt CO2/yr)"))
+        # setNames(climatePools,              paste0("Emissions|CO2|Land|Land-use Change|++|", getNames(climatePools), " (Mt CO2/yr)"))
       )
     )
-
-    #Add peatland N2O emissions
-    if(emi == "n2o") {
-      x <- mbind(
-        x,
-        setNames(
-          dimSums(a[, , c(peatland)], dim = 3),
-          paste0(prefix, "|+|Peatland (Mt ", emi2, "/yr)")
-        ),
-        setNames(
-          dimSums(a[, , c("peatland")], dim = 3),
-          paste0(prefix, "|Peatland|+|Managed (Mt ", emi2, "/yr)")
+    
+    # Only attempt to append wood-related reports if the forestry module was activated
+    if (!is.null(yearlyCO2$wood)) {
+        emissionsReport <- with(yearlyCO2, 
+          mbind(
+            emissionsReport,
+            setNames(wood,                      "Emissions|CO2|Land|Land-use Change|+|Wood Harvest (Mt CO2/yr)"),
+            setNames(emisWoodFuel,              "Emissions|CO2|Land|Land-use Change|Wood Harvest|Short Lived Products (Mt CO2/yr)"),
+            setNames(storage,                   "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage (Mt CO2/yr)"), # carbon stored in wood products + release from wood products
+            # setNames(inflow,                  "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Inflow (Mt CO2/yr)"), # carbon stored in wood products
+            # setNames(outlow,                  "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Outflow (Mt CO2/yr)"), # slow release from wood products
+            setNames(emisWoodNet,               "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Industrial roundwood (Mt CO2/yr)"), # carbon stored in Industrial roundwood + release from Industrial roundwood
+            setNames(emisWoodInflow,            "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Inflow (Mt CO2/yr)"), # carbon stored in Industrial roundwood
+            setNames(emisWoodOutflow,           "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Outflow (Mt CO2/yr)"), # slow release from Industrial roundwood
+            setNames(emisBuildingNet,           "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Buildings (Mt CO2/yr)"), # carbon stored in wood buildings + release from wood buildings
+            setNames(emisBuildingInflow,        "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Mt CO2/yr)"), # carbon stored in wood buildings
+            setNames(emisBuildingOutflow,       "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Mt CO2/yr)"), # slow release from wood buildings
+          )
         )
+    } 
+    # end nolint
+    
+    
+    # -----------------------------------------------------------------------------------------------------------------
+    # RAW yearly CO2 emissions, lowpass = 0
+    
+    rawYearlyCO2 <- .calcCO2(.lowpass = 0, .cumulative = FALSE, .raw = TRUE)
+    
+    # nolint
+    emissionsReport <- with(rawYearlyCO2,
+      mbind(
+          emissionsReport, 
+          setNames(total,         "Emissions|CO2|Land RAW (Mt CO2/yr)"), # All human-induced land-related CO2 emissions
+          setNames(landuseTotal,  "Emissions|CO2|Land RAW|+|Land-use Change RAW (Mt CO2/yr)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
+          setNames(climateChange, "Emissions|CO2|Land RAW|+|Indirect RAW (Mt CO2/yr)") # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
       )
-    }
-  }
-
-
-  # CH4
-  agricult_ch4 <- c("rice", "awms", "ent_ferm")
-  burn_ch4 <- c("resid_burn")
-  peatland_ch4 <- "peatland"
-
-  #combine all CH4 emissions in one object
-  a <- collapseNames(Emissions(gdx, level = "regglo", type = "ch4", unit = "gas", subcategories = TRUE), collapsedim = 2)
-  #Add peatland emissions if missing
-  if(!"peatland" %in% getNames(a,dim=1)) {
-    peatland <- PeatlandEmissions(gdx, unit = "gas", level = "regglo")
-    if (!is.null(peatland)) {
-      peatland <- setNames(collapseNames(peatland[, , "ch4"]),"peatland")
-    } else {
-      peatland <- NULL
-    }
-    a <- mbind(a,peatland)
-  }
-
-  #subset, aggregate, rename and combine CH4 emissions
-  x <- mbind(x,
-             setNames(dimSums(a[,,c(agricult_ch4,burn_ch4,peatland_ch4)], dim = 3), "Emissions|CH4|Land (Mt CH4/yr)"),
-             setNames(dimSums(a[,,agricult_ch4], dim = 3), "Emissions|CH4|Land|+|Agriculture (Mt CH4/yr)"),
-             setNames(dimSums(a[, , c("rice")], dim = 3), "Emissions|CH4|Land|Agriculture|+|Rice (Mt CH4/yr)"),
-             setNames(dimSums(a[, , c("awms")], dim = 3), "Emissions|CH4|Land|Agriculture|+|Animal waste management (Mt CH4/yr)"),
-             setNames(dimSums(a[, , c("ent_ferm")], dim = 3), "Emissions|CH4|Land|Agriculture|+|Enteric fermentation (Mt CH4/yr)"),
-             setNames(dimSums(a[, , c(burn_ch4)], dim = 3),"Emissions|CH4|Land|+|Biomass Burning (Mt CH4/yr)"),
-             setNames(dimSums(a[, , c("resid_burn")], dim = 3),"Emissions|CH4|Land|Biomass Burning|+|Burning of Crop Residues (Mt CH4/yr)"),
-             setNames(dimSums(a[, , c(peatland_ch4)], dim = 3),"Emissions|CH4|Land|+|Peatland (Mt CH4/yr)"),
-             setNames(dimSums(a[, , c("peatland")], dim = 3),"Emissions|CH4|Land|Peatland|+|Managed (Mt CH4/yr)")
-  )
-
-  #####
-  # Append N2O GWP100AR6
-
-  appendEmissionN2O <- function(.unit) {
-    agriculture <- c("SOM", "inorg_fert", "man_crop", "awms", "resid", "man_past", "rice")
-
-    emissions <- Emissions(gdx, level = "regglo", type = "n2o_n", unit = .unit, subcategories = TRUE)
-    emissions <- collapseNames(emissions, collapsedim = 2)
-
-    .createReport <- function(.emission, .name = NULL) {
-      t <- dimSums(emissions[, , .emission], dim = 3)
-      n <- paste0("Emissions|N2O_", .unit, "|Land", .name, " (Mt CO2e/yr)")
-      return(setNames(t, n))
-    }
-
-    #nolint start
-    .x <- mbind(
-      .createReport(c(agriculture, "resid_burn", "peatland")),
-      .createReport(c(agriculture),                                                   "|+|Agriculture"),
-      .createReport(c("awms"),                                                        "|Agriculture|+|Animal Waste Management"),
-      .createReport(c("inorg_fert", "man_crop", "resid", "SOM", "rice", "man_past"),  "|Agriculture|+|Agricultural Soils"),
-      .createReport(c("inorg_fert", "rice"),                                          "|Agriculture|Agricultural Soils|+|Inorganic Fertilizers"),
-      .createReport(c("inorg_fert_crop", "rice"),                                     "|Agriculture|Agricultural Soils|Inorganic Fertilizers|+|Cropland"),
-      .createReport(c("inorg_fert_past"),                                             "|Agriculture|Agricultural Soils|Inorganic Fertilizers|+|Pasture"),
-      .createReport(c("man_crop"),                                                    "|Agriculture|Agricultural Soils|+|Manure applied to Croplands"),
-      .createReport(c("resid"),                                                       "|Agriculture|Agricultural Soils|+|Decay of Crop Residues"),
-      .createReport(c("SOM"),                                                         "|Agriculture|Agricultural Soils|+|Soil Organic Matter Loss"),
-      .createReport(c("man_past"),                                                    "|Agriculture|Agricultural Soils|+|Pasture"),
-      .createReport(c("resid_burn"),                                                  "|+|Biomass Burning"),
-      .createReport(c("resid_burn"),                                                  "|Biomass Burning|+|Burning of Crop Residues"),
-      .createReport(c("peatland"),                                                    "|+|Peatland"),
-      .createReport(c("peatland"),                                                    "|Peatland|+|Managed")
     )
-    #nolint end
-
-    return(.x)
-  }
-
-  x <- mbind(x, appendEmissionN2O("GWP100AR6"))
-
-  #####
-  # Append CH4 GWP100AR6 and GWP*AR6 to output object
-
-  appendEmissionCH4 <- function(.unit) {
-
-    emissions <- Emissions(gdx, level = "regglo", type = "ch4", unit = .unit, subcategories = TRUE)
-    emissions <- collapseNames(emissions, collapsedim = 2)
-
-    .createReport <- function(.emission, .name = NULL) {
-      t <- dimSums(emissions[, , .emission], dim = 3)
-      n <- paste0("Emissions|CH4_", .unit, "|Land", .name, " (Mt CO2e/yr)")
-      return(setNames(t, n))
-    }
-
-    #nolint start
-    .x <- mbind(
-      .createReport(c("rice", "awms", "ent_ferm", "resid_burn", "peatland")),
-      .createReport(c("rice", "awms", "ent_ferm"),                            "|+|Agriculture"),
-      .createReport(c("rice"),                                                "|Agriculture|+|Rice"),
-      .createReport(c("awms"),                                                "|Agriculture|+|Animal waste management"),
-      .createReport(c("ent_ferm"),                                            "|Agriculture|+|Enteric fermentation"),
-      .createReport(c("resid_burn"),                                          "|+|Biomass Burning"),
-      .createReport(c("resid_burn"),                                          "|Biomass Burning|+|Burning of Crop Residues"),
-      .createReport(c("peatland"),                                            "|+|Peatland"),
-      .createReport(c("peatland"),                                            "|Peatland|+|Managed")
+    # end nolint
+    
+    
+    # -----------------------------------------------------------------------------------------------------------------
+    # Cumulative CO2 emissions, lowpass = 3
+    
+    cumulativeCO2 <- .calcCO2(.lowpass = 3, .cumulative = TRUE)
+    
+    # nolint
+    emissionsReport <- with(cumulativeCO2, 
+      mbind(
+          emissionsReport,
+          setNames(total,                     "Emissions|CO2|Land|Cumulative (Gt CO2)"), # All human-induced land-related CO2 emissions
+          setNames(landuseTotal,              "Emissions|CO2|Land|Cumulative|+|Land-use Change (Gt CO2)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
+          setNames(climateChange,             "Emissions|CO2|Land|Cumulative|+|Indirect (Gt CO2)"), # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
+          setNames(landuseChange,             "Emissions|CO2|Land|Cumulative|Land-use Change|+|Gross LUC (Gt CO2)"), # land-use change
+          setNames(degradation,               "Emissions|CO2|Land|Cumulative|Land-use Change|Gross LUC|+|Forest Degradation (Mt CO2/yr)"), # forest Degradation
+          setNames(totalRegrowth,             "Emissions|CO2|Land|Cumulative|Land-use Change|+|Regrowth (Gt CO2)"), # regrowth of vegetation
+          setNames(regrowthAffCO2Price,       "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|CO2-price AR (Gt CO2)"), # regrowth of vegetation
+          setNames(regrowthAffNPI_NDC,        "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|NPI_NDC AR (Gt CO2)"), # regrowth of vegetation
+          setNames(regrowthPlantations,       "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|Timber Plantations (Gt CO2)"), # regrowth of vegetation
+          setNames(regrowthSecondaryForests,  "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|Secondary Forest (Gt CO2)"), # regrowth of vegetation
+          setNames(regrowthOther,             "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|Other Land (Gt CO2)"), # regrowth of vegetation
+          setNames(peatland,                  "Emissions|CO2|Land|Cumulative|Land-use Change|+|Peatland (Gt CO2)")
+      )
     )
-    #nolint end
+    
+    if (!is.null(cumulativeCO2$wood)) {
+        emissionsReport <- with(cumulativeCO2, 
+          mbind(
+              emissionsReport,
+              setNames(wood,                      "Emissions|CO2|Land|Cumulative|Land-use Change|+|Wood Harvest (Gt CO2)"),
+              setNames(emisWoodFuel,              "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Short Lived Products (Gt CO2)"),
+              setNames(storage,                   "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage (Gt CO2)"), # carbon stored in wood products + release from wood products
+              # setNames(inflow,                  "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Inflow (Gt CO2)"), # carbon stored in wood products
+              # setNames(outlow,                  "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Outflow (Gt CO2)"), # slow release from wood products
+              setNames(emisWoodNet,               "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|+|Industrial roundwood (Gt CO2)"), # carbon stored in Industrial roundwood + release from Industrial roundwood
+              setNames(emisWoodInflow,            "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Inflow (Gt CO2)"), # carbon stored in Industrial roundwood
+              setNames(emisWoodOutflow,           "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Outflow (Gt CO2)"), # slow release from Industrial roundwood
+              setNames(emisBuildingNet,           "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|+|Buildings (Gt CO2)"), # carbon stored in wood buildings + release from wood buildings
+              setNames(emisBuildingInflow,        "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Gt CO2)"), # carbon stored in wood buildings
+              setNames(emisBuildingOutflow,       "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Gt CO2)") # slow release from wood 
+          )
+        )
+    }
+    # end nolint  
+    
 
-    return(.x)
-  }
+    # -----------------------------------------------------------------------------------------------------------------
+    # N2O, NOx, NH3 emissions reporting
+    
+    .generateNitrogenReport <- function(.type) {
+        
+        .createReport <- function(.emission, .source, .name = NULL) {
+            type <- getItems(.emission, dim = 3.2)
+            
+            unit <- type
+            if (unit %in% c("n2o_direct", "n2o_indirect")) {
+                unit <- "n2o"
+            }
+            unit <- reportingnames(unit)
+            
+            t <- dimSums(.emission[, , .source], dim = 3)
+            n <- paste0("Emissions|", reportingnames(type), "|Land", .name, " (Mt ", unit, "/yr)")
+            return(setNames(t, n))
+        }
+         
+        nEmissions <- Emissions(gdx, level = "regglo", type = .type, unit = "gas", subcategories = TRUE, inorg_fert_split = TRUE)
 
-  x <- mbind(x,
-    appendEmissionCH4("GWP100AR6"),
-    appendEmissionCH4("GWP*AR6"))
+        agriculture <- c("SOM", "inorg_fert", "man_crop", "awms", "resid", "man_past", "rice")
+        burn <- c("resid_burn")
+        peatland_n2o <- c("peatland")
+        
+        # For backwards compatibility, add peatland N2O emissions if they were not already returned by Emissions.R 
+        if (.type == "n2o_n" && !("peatland" %in% getItems(nEmissions, dim = 3.1))) {
+            
+            peatlandEmissions <- PeatlandEmissions(gdx, unit = "gas", level = "regglo")
+            if (!is.null(peatlandEmissions)) {
+                peatlandEmissions <- collapseNames(peatlandEmissions[, , "n2o"])
+                getNames(peatlandEmissions) <- "peatland.n2o"
+            } 
 
+            nEmissions <- mbind(nEmissions, peatlandEmissions)
+        }
+        
 
-  #####
-  # Append total yearly CO2e (for GWP100AR6)
+        # nolint
+        .x <- mbind(
+            .createReport(nEmissions, c(agriculture, burn, peatland_n2o)), 
+            .createReport(nEmissions, agriculture,                                                     "|+|Agriculture"), 
+            .createReport(nEmissions, "awms",                                                          "|Agriculture|+|Animal Waste Management"), 
+            .createReport(nEmissions, c("inorg_fert", "man_crop", "resid", "SOM", "rice", "man_past"), "|Agriculture|+|Agricultural Soils"), 
+            .createReport(nEmissions, c("inorg_fert", "rice"),                                         "|Agriculture|Agricultural Soils|+|Inorganic Fertilizers"), 
+            .createReport(nEmissions, c("inorg_fert_crop", "rice"),                                    "|Agriculture|Agricultural Soils|Inorganic Fertilizers|+|Cropland"), 
+            .createReport(nEmissions, c("inorg_fert_past"),                                            "|Agriculture|Agricultural Soils|Inorganic Fertilizers|+|Pasture"), 
+            .createReport(nEmissions, c("man_crop"),                                                   "|Agriculture|Agricultural Soils|+|Manure applied to Croplands"), 
+            .createReport(nEmissions, c("resid"),                                                      "|Agriculture|Agricultural Soils|+|Decay of Crop Residues"), 
+            .createReport(nEmissions, c("SOM"),                                                        "|Agriculture|Agricultural Soils|+|Soil Organic Matter Loss"), 
+            # .createReport(nEmissions, c("rice"),                                                       "|Agriculture|Agricultural Soils|+|Lower N2O emissions of rice"), 
+            .createReport(nEmissions, c("man_past"),                                                   "|Agriculture|Agricultural Soils|+|Pasture"), 
+            .createReport(nEmissions, burn,                                                            "|+|Biomass Burning"), 
+            .createReport(nEmissions, c("resid_burn"),                                                 "|Biomass Burning|+|Burning of Crop Residues")
+        )
+        # end nolint
+            
+        # Old versions of MAgPIE may not include peatlands
+        if ("peatland" %in% getItems(nEmissions, dim = 3.1)) {
 
-  appendTotalGWP <- function(.unit) {
-    reports <- c(paste0("Emissions|CH4_", .unit, "|Land (Mt CO2e/yr)"),
-                 paste0("Emissions|N2O_", .unit, "|Land (Mt CO2e/yr)"),
-                 "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)")
+            .x <- mbind(
+                .x,
+                .createReport(nEmissions, peatland_n2o,  "|+|Peatland"),
+                .createReport(nEmissions, c("peatland"), "|Peatland|+|Managed")
+            )
+            
+        }
+        
+        return(.x)
+        
+    }
+    
+    nEmisTypes <- c("n2o_n", "nh3_n", "no2_n", "no3_n", "n2o_n_direct", "n2o_n_indirect")
+    nitrogenEmissions <- mbind(lapply(X = nEmisTypes, FUN = .generateNitrogenReport))
+    emissionsReport <- mbind(emissionsReport, nitrogenEmissions)
+    
 
-    total <- dimSums(x[, , reports], dim = 3) * 0.001 # Mt to Gt CO2e
-    total <- setNames(total, paste0("Emissions|", .unit, "|Land (Gt CO2e/yr)"))
+    # -----------------------------------------------------------------------------------------------------------------
+    # CH4 emissions reporting
+    
+    agricult_ch4 <- c("rice", "awms", "ent_ferm")
+    burn_ch4 <- c("resid_burn")
+    peatland_ch4 <- "peatland"
+    
+    # combine all CH4 emissions in one object
+    ch4 <- collapseNames(Emissions(gdx, level = "regglo", type = "ch4", unit = "gas", subcategories = TRUE), collapsedim = 2)
+    
+    # Add peatland emissions if missing
+    if (!"peatland" %in% getNames(ch4, dim = 1)) {
+        
+        peatlandEmissions <- PeatlandEmissions(gdx, unit = "gas", level = "regglo")
+        if (!is.null(peatlandEmissions)) {
+            peatlandEmissions <- setNames(collapseNames(peatlandEmissions[, , "ch4"]), "peatland")
+        }
+        ch4 <- mbind(ch4, peatlandEmissions)
+    }
+    
+    # nolint
+    emissionsReport <- mbind(
+        emissionsReport,
+        setNames(dimSums(ch4[, , c(agricult_ch4, burn_ch4, peatland_ch4)], dim = 3), "Emissions|CH4|Land (Mt CH4/yr)"),
+        setNames(dimSums(ch4[, , agricult_ch4], dim = 3),                            "Emissions|CH4|Land|+|Agriculture (Mt CH4/yr)"),
+        setNames(dimSums(ch4[, , c("rice")], dim = 3),                               "Emissions|CH4|Land|Agriculture|+|Rice (Mt CH4/yr)"),
+        setNames(dimSums(ch4[, , c("awms")], dim = 3),                               "Emissions|CH4|Land|Agriculture|+|Animal waste management (Mt CH4/yr)"),
+        setNames(dimSums(ch4[, , c("ent_ferm")], dim = 3),                           "Emissions|CH4|Land|Agriculture|+|Enteric fermentation (Mt CH4/yr)"),
+        setNames(dimSums(ch4[, , c(burn_ch4)], dim = 3),                             "Emissions|CH4|Land|+|Biomass Burning (Mt CH4/yr)"),
+        setNames(dimSums(ch4[, , c("resid_burn")], dim = 3),                         "Emissions|CH4|Land|Biomass Burning|+|Burning of Crop Residues (Mt CH4/yr)"),
+        setNames(dimSums(ch4[, , c(peatland_ch4)], dim = 3),                         "Emissions|CH4|Land|+|Peatland (Mt CH4/yr)"),
+        setNames(dimSums(ch4[, , c("peatland")], dim = 3),                           "Emissions|CH4|Land|Peatland|+|Managed (Mt CH4/yr)")
+    )
+    # end nolint
+    
 
-    return(total)
-  }
+    # -----------------------------------------------------------------------------------------------------------------
+    # N2O GWP100AR6 emissions reporting
+    
+    .generateGWPN2O <- function(.unit) {
+        
+        agriculture <- c("SOM", "inorg_fert", "man_crop", "awms", "resid", "man_past", "rice")
+        
+        emissions <- Emissions(gdx, level = "regglo", type = "n2o_n", unit = .unit, subcategories = TRUE)
+        emissions <- collapseNames(emissions, collapsedim = 2)
+        
+        .createReport <- function(.emission, .name = NULL) {
+            t <- dimSums(emissions[, , .emission], dim = 3)
+            n <- paste0("Emissions|N2O_", .unit, "|Land", .name, " (Mt CO2e/yr)")
+            return(setNames(t, n))
+        }
+        
+        # nolint
+        .x <- mbind(
+            .createReport(c(agriculture, "resid_burn", "peatland")),
+            .createReport(c(agriculture),                                                   "|+|Agriculture"),
+            .createReport(c("awms"),                                                        "|Agriculture|+|Animal Waste Management"),
+            .createReport(c("inorg_fert", "man_crop", "resid", "SOM", "rice", "man_past"),  "|Agriculture|+|Agricultural Soils"),
+            .createReport(c("inorg_fert", "rice"),                                          "|Agriculture|Agricultural Soils|+|Inorganic Fertilizers"),
+            .createReport(c("inorg_fert_crop", "rice"),                                     "|Agriculture|Agricultural Soils|Inorganic Fertilizers|+|Cropland"),
+            .createReport(c("inorg_fert_past"),                                             "|Agriculture|Agricultural Soils|Inorganic Fertilizers|+|Pasture"),
+            .createReport(c("man_crop"),                                                    "|Agriculture|Agricultural Soils|+|Manure applied to Croplands"),
+            .createReport(c("resid"),                                                       "|Agriculture|Agricultural Soils|+|Decay of Crop Residues"),
+            .createReport(c("SOM"),                                                         "|Agriculture|Agricultural Soils|+|Soil Organic Matter Loss"),
+            .createReport(c("man_past"),                                                    "|Agriculture|Agricultural Soils|+|Pasture"),
+            .createReport(c("resid_burn"),                                                  "|+|Biomass Burning"),
+            .createReport(c("resid_burn"),                                                  "|Biomass Burning|+|Burning of Crop Residues"),
+            .createReport(c("peatland"),                                                    "|+|Peatland"),
+            .createReport(c("peatland"),                                                    "|Peatland|+|Managed")
+        )
+        # end nolint
+        
+        return(.x)
+    }
+    
+    emissionsReport <- mbind(
+      emissionsReport, 
+      .generateGWPN2O("GWP100AR6")
+    )
+    
+    
+    # -----------------------------------------------------------------------------------------------------------------
+    # CH4 GWP100AR6 and GWP*AR6 emissions reporting
+    
+    .generateGWPCH4 <- function(.unit) {
+        
+        emissions <- Emissions(gdx, level = "regglo", type = "ch4", unit = .unit, subcategories = TRUE)
+        emissions <- collapseNames(emissions, collapsedim = 2)
+        
+        .createReport <- function(.emission, .name = NULL) {
+            t <- dimSums(emissions[, , .emission], dim = 3)
+            n <- paste0("Emissions|CH4_", .unit, "|Land", .name, " (Mt CO2e/yr)")
+            return(setNames(t, n))
+        }
+        
+        # nolint
+        .x <- mbind(
+            .createReport(c("rice", "awms", "ent_ferm", "resid_burn", "peatland")),
+            .createReport(c("rice", "awms", "ent_ferm"),                            "|+|Agriculture"),
+            .createReport(c("rice"),                                                "|Agriculture|+|Rice"),
+            .createReport(c("awms"),                                                "|Agriculture|+|Animal waste management"),
+            .createReport(c("ent_ferm"),                                            "|Agriculture|+|Enteric fermentation"),
+            .createReport(c("resid_burn"),                                          "|+|Biomass Burning"),
+            .createReport(c("resid_burn"),                                          "|Biomass Burning|+|Burning of Crop Residues"),
+            .createReport(c("peatland"),                                            "|+|Peatland"),
+            .createReport(c("peatland"),                                            "|Peatland|+|Managed")
+        )
+        # nolint end
+        
+        return(.x)
+    }
+    
+    emissionsReport <- mbind(
+        emissionsReport,
+        .generateGWPCH4("GWP100AR6"),
+        .generateGWPCH4("GWP*AR6")
+    )
+    
+    
+    # -----------------------------------------------------------------------------------------------------------------
+    # Total yearly CO2e (for GWP100AR6) emissions reporting
+    
+    .generateTotalGWP <- function(.unit) {
+        reports <- c(paste0("Emissions|CH4_", .unit, "|Land (Mt CO2e/yr)"),
+                     paste0("Emissions|N2O_", .unit, "|Land (Mt CO2e/yr)"),
+                     "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)")
+        
+        total <- dimSums(emissionsReport[, , reports], dim = 3) * 0.001 # Mt to Gt CO2e
+        total <- setNames(total, paste0("Emissions|", .unit, "|Land (Gt CO2e/yr)"))
+        
+        return(total)
+    }
+    
+    emissionsReport <- mbind(
+        emissionsReport, 
+        .generateTotalGWP("GWP100AR6")
+    )
+    
+    
+    # -----------------------------------------------------------------------------------------------------------------
+    # Total cumulative CO2e (for GWP100AR6) emissions reporting
+    
+    .generateCumulativeGWP <- function(.unit) {
+        
+        years <- getYears(emissionsReport, as.integer = TRUE)
+        
+        # accumulate flow reports (CH4, N2O)
+        flows <- emissionsReport[, , c(paste0("Emissions|CH4_", .unit, "|Land (Mt CO2e/yr)"),
+                                       paste0("Emissions|N2O_", .unit, "|Land (Mt CO2e/yr)"))]
+        flows <- flows[, years, ]
+        flows[, c("y1995", "y2000"), ] <- 0
+        
+        flows <- time_interpolate(flows, interpolated_year = min(years):max(years))
+        flows <- as.magpie(apply(flows, c(1, 3), cumsum))
+        flows <- flows[, years, ]
+        
+        # accumulate stock reports (CO2)
+        stock <- emissionsReport[, , "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)"]
+        stock <- stock[, years, ]
+        stock[, c("y1995", "y2000"), ] <- 0
+        
+        im_years <- m_yeardiff(gdx)[, years, ]
+        stock <- stock * im_years
+        stock <- as.magpie(apply(stock, c(1, 3), cumsum))
+        
+        # combine accounting of stocks and flows
+        all <- setNames(stock, NULL) + dimSums(flows, dim = 3)
+        all <- all * 0.001  # Mt to Gt CO2e
+        all <- setNames(all, paste0("Emissions|", .unit, "|Land|Cumulative (Gt CO2e)"))
+        
+        all[, "y1995", ] <- NA
+        
+        return(all)
+    }
+    
+    emissionsReport <- mbind(
+        emissionsReport, 
+        .generateCumulativeGWP("GWP100AR6")
+    )
+    
+    return(emissionsReport)
 
-  x <- mbind(x, appendTotalGWP("GWP100AR6"))
-
-  #####
-  # Append total cumulative CO2e (for GWP100AR6)
-
-  appendCumGWP <- function(.unit) {
-
-    years <- getYears(x, as.integer = TRUE)
-
-    # accumulate flow reports (CH4, N2O)
-    flows <- x[, , c(paste0("Emissions|CH4_", .unit, "|Land (Mt CO2e/yr)"),
-                     paste0("Emissions|N2O_", .unit, "|Land (Mt CO2e/yr)"))]
-    flows <- flows[, years, ]
-    flows[, c("y1995", "y2000"), ] <- 0
-
-    flows <- time_interpolate(flows, interpolated_year = min(years):max(years))
-    flows <- as.magpie(apply(flows, c(1, 3), cumsum))
-    flows <- flows[, years, ]
-
-    # accumulate stock reports (CO2)
-    stock <- x[, , "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)"]
-    stock <- stock[, years, ]
-    stock[, c("y1995", "y2000"), ] <- 0
-
-    im_years <- m_yeardiff(gdx)[, years, ]
-    stock <- stock * im_years
-    stock <- as.magpie(apply(stock, c(1, 3), cumsum))
-
-    # combine accounting of stocks and flows
-    all <- setNames(stock, NULL) + dimSums(flows, dim = 3)
-    all <- all * 0.001  # Mt to Gt CO2e
-    all <- setNames(all, paste0("Emissions|", .unit, "|Land|Cumulative (Gt CO2e)"))
-
-    all[, "y1995", ] <- NA
-
-    return(all)
-  }
-
-  x <- mbind(x, appendCumGWP("GWP100AR6"))
-
-  return(x)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **1.189.5**
+R package **magpie4**, version **1.190.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magpie4)](https://cran.r-project.org/package=magpie4) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M (2023). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi: 10.5281/zenodo.1158582 (URL: https://doi.org/10.5281/zenodo.1158582), R package version 1.189.5, <URL: https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M (2023). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi: 10.5281/zenodo.1158582 (URL: https://doi.org/10.5281/zenodo.1158582), R package version 1.190.0, <URL: https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves},
   year = {2023},
-  note = {R package version 1.189.5},
+  note = {R package version 1.190.0},
   doi = {10.5281/zenodo.1158582},
   url = {https://github.com/pik-piam/magpie4},
 }

--- a/man/reportEmissions.Rd
+++ b/man/reportEmissions.Rd
@@ -4,15 +4,17 @@
 \alias{reportEmissions}
 \title{reportEmissions}
 \usage{
-reportEmissions(gdx, storage_wood = TRUE)
+reportEmissions(gdx, storageWood = TRUE, grassi = TRUE)
 }
 \arguments{
 \item{gdx}{GDX file}
 
-\item{storage_wood}{Accounting for long term carbon storage in wood products. Default is TRUE}
+\item{storageWood}{Accounting for long term carbon storage in wood products. Default is TRUE.}
+
+\item{grassi}{Replace MAgPIE's internal accounting of indirect emissions from land-use change with the estimates of Grassi et al.}
 }
 \value{
-GHG emissions as MAgPIE object (Unit: Mt CO2/yr, Mt N2O/yr and Mt CH4/yr)
+GHG emissions as MAgPIE object (Unit: Mt CO2/yr, Mt N2O/yr, and Mt CH4/yr, for cumulative emissions Gt CO2)
 }
 \description{
 reports GHG emissions
@@ -43,7 +45,8 @@ raw data; no low pass filter applied\tabular{lll}{
 \dontrun{
 x <- reportEmissions(gdx)
 }
+
 }
 \author{
-Florian Humpenoeder, Benjamin Leon Bodirsky
+Florian Humpenoeder, Benjamin Leon Bodirsky, Michael Crawford
 }


### PR DESCRIPTION
This is a re-write of the reportEmissions.R function, which additionally adds the option to calculate the land-use sink without the Grassi coefficients.

The primary focus of the re-write was to simplify the CO2 calculation's structure and then subsequent reporting. There is now a local function, .calcCO2, that takes as arguments ".lowpass", ".cumulative", and ".raw". The CO2 reports are thus now single calls to this function and the subsequent naming of the reporting variables.

A secondary aspect was simplifying the nitrogen reporting, also through the use of helper functions. This process revealed that peatland emissions had previously been left out of the `N2O|Direct|...` reporting variables (though was present in the larger N2O variable). This is now fixed.

### Testing

I tested this function by anti_joining this version of the reportEmissions function with the current piam magpie4 version for a MAgPIE .gdx file. The differences are:

1. `Emissions|N2O|Direct|Land (Mt N2O/yr)` Now includes the previously unaccounted peatland emissions.
2. This list of emissions now exists in the final reporting object:

```
 [1] Emissions|NH3|Land|+|Peatland (Mt NH3/yr)                 
 [2] Emissions|NH3|Land|Peatland|+|Managed (Mt NH3/yr)         
 [3] Emissions|NO2|Land|+|Peatland (Mt NO2/yr)                 
 [4] Emissions|NO2|Land|Peatland|+|Managed (Mt NO2/yr)         
 [5] Emissions|NO3-|Land|+|Peatland (Mt NO3-/yr)               
 [6] Emissions|NO3-|Land|Peatland|+|Managed (Mt NO3-/yr)       
 [7] Emissions|N2O|Direct|Land (Mt N2O/yr)                     
 [8] Emissions|N2O|Direct|Land|+|Peatland (Mt N2O/yr)          
 [9] Emissions|N2O|Direct|Land|Peatland|+|Managed (Mt N2O/yr)  
[10] Emissions|N2O|Indirect|Land|+|Peatland (Mt N2O/yr)        
[11] Emissions|N2O|Indirect|Land|Peatland|+|Managed (Mt N2O/yr)
```

Only the `N2O|Direct|...` variables are populated with non-zero values. The rest of these emissions are currently 0 for each of the reports.

### Land-carbon sink with and without Grassi emissions

I incorporate the following code to either replace the "MAgPIE-own" land-carbon sink with the Grassi coefficients:

```
# Replace indirect emissions from climate change on managed land with the Grassi coefficients?
if (grassi) {
    climateChange <- landCarbonSink(gdx, level = "regglo", cumulative = .cumulative)
} else {
    climateChange <- dimSums(co2[, , "cc"], dim = 3)
}
```

And test this new code with some runs of Gabriel's, which varied the climate change, the RCP, the peak carbon budget, and afforestation. I don't completely understand the results. In particular, I wonder if there was something strange in his runs' afforestation settings, because it makes no difference in the end, in terms of CO2 emissions. That said, for the plots of indirect emissions it does seem that the land-carbon sink is working as expected.

#### Land-use Change

[LanduseChange.pdf](https://github.com/pik-piam/magpie4/files/12247420/LanduseChange.pdf)

#### Indirect

[Indirect.pdf](https://github.com/pik-piam/magpie4/files/12247423/Indirect.pdf)

#### Land

[Land.pdf](https://github.com/pik-piam/magpie4/files/12247424/Land.pdf)

### Outstanding questions

1. I'm not sure if Grassi should be an argument to the larger function or have its own reporting variables in the final reporting document. On one side, unless we are going to be using these values it may be potentially confusing. On the other hand, the only way to retrieve the "MAgPIE-own" land-use sink with this implementation is to call reportEmissions.R by hand. Certainly not the most convenient method.
2. On L115 the value for `storage` in the context of wood products is written over, without the older value of the variable ever being used. I'm not sure if this is desired behavior.


