### PR TITLE
fix rworldmap / elide warnings, correct unit USD -> USD05

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '238911130'
+ValidationKey: '238942998'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 1.206.5
-date-released: '2024-03-20'
+version: 1.206.6
+date-released: '2024-03-21'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 1.206.5
-Date: 2024-03-20
+Version: 1.206.6
+Date: 2024-03-21
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),
@@ -56,7 +56,7 @@ Suggests:
     covr,
     luplot,
     ncdf4,
-    rworldmap,
+    rworldmap (>= 1.3.8),
     terra,
     testthat
 Encoding: UTF-8

--- a/R/reportFoodExpenditure.R
+++ b/R/reportFoodExpenditure.R
@@ -19,7 +19,7 @@
 reportFoodExpenditure<-function(gdx,detail=FALSE,level="regglo"){
   out<-FoodExpenditure(gdx,level = level,products="kall",product_aggr = FALSE)
   out<-reporthelper(x=out,level_zero_name = "Household Expenditure|Food|Expenditure",detail = detail,partly = TRUE)
-  getNames(out) <- paste(getNames(out),"(USD/capita)",sep=" ")
+  getNames(out) <- paste(getNames(out),"(USD05/capita)",sep=" ")
 
   out2<-FoodExpenditureShare(gdx,level=level,products = "kfo",product_aggr = TRUE)
   getNames(out2) <- "Household Expenditure|Food|Food Expenditure Share (USD05/USD05)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **1.206.5**
+R package **magpie4**, version **1.206.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magpie4)](https://cran.r-project.org/package=magpie4) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M (2024). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi: 10.5281/zenodo.1158582 (URL: https://doi.org/10.5281/zenodo.1158582), R package version 1.206.5, <URL: https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M (2024). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi: 10.5281/zenodo.1158582 (URL: https://doi.org/10.5281/zenodo.1158582), R package version 1.206.6, <URL: https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves},
   year = {2024},
-  note = {R package version 1.206.5},
+  note = {R package version 1.206.6},
   doi = {10.5281/zenodo.1158582},
   url = {https://github.com/pik-piam/magpie4},
 }


### PR DESCRIPTION
- we need `rworldmap (>= 1.3.8)` because [in this version, the dependency on maptools was removed](https://github.com/andysouth/rworldmap/commit/09f9a144909aa2a42712ccac279fafd36a562c75#diff-b6b6854a02ae177f8860f49654ff250c1554d021ae434b6efdbe99d00bdc6055).
- maptools creates a `Warning: multiple methods tables found for ‘elide’` problem if used together with `sp` since they copied the [`elide` method from maptools](https://github.com/edzer/sp/commit/37ab639c4aded9c8179a0d1051378f83117a8074)
- also be more precise on a unit that was `USD` -> `USD05` as discussed some days ago