### PR TITLE
Revision of emisCO2.R

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 2.1.0
-date-released: '2024-05-13'
+version: 2.2.0
+date-released: '2024-05-22'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 2.1.0
-Date: 2024-05-13
+Version: 2.2.0
+Date: 2024-05-22
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/emisCO2.R
+++ b/R/emisCO2.R
@@ -618,7 +618,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     # when the carbon densities change more than the area effect, they will determine the direction,
     # even though the area may have technically been "deforested" or "regrowing". Maybe I would check
     # to see if cc is on, and then run the check only if so?
-    )
+    
   }
 
   ###

--- a/R/emisCO2.R
+++ b/R/emisCO2.R
@@ -610,7 +610,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     # --- Ensure that total net emissions are additive of cc, lu, and interaction (now included in cc)
     totalEmissions <- output[, , "total"]
     componentEmissions <- dimSums(output[, , c("cc", "lu")], dim = 3.3)
-    if (any(totalEmissions - componentEmissions > 1e-05, na.rm = TRUE)) {
+    if (any(totalEmissions - componentEmissions > 1e-06, na.rm = TRUE)) {
       stop("Inapprpopriately high residuals in main emissions in magpie4::emisCO2")
     }
 

--- a/R/emisCO2.R
+++ b/R/emisCO2.R
@@ -24,7 +24,9 @@
 #' @param lowpass number of lowpass filter iterations (default = 3)
 #' @return CO2 emissions as MAgPIE object (unit depends on \code{unit})
 #' @author Florian Humpenoeder, Michael Crawford
-#' @importFrom magclass new.magpie getCells lowpass setNames getNames getYears setYears
+#' @importFrom magclass dimSums add_dimension getSets getCells getNames add_columns 
+#'  collapseNames collapseDim nyears getYears setYears getItems new.magpie as.magpie
+#' @importFrom gdx readGDX
 #' @examples
 #' \dontrun{
 #' x <- emisCO2(gdx)
@@ -133,6 +135,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     pasture           <- fm_carbon_density[, , "past"]
     urban             <- fm_carbon_density[, , "urban"]
     primforest        <- fm_carbon_density[, , "primforest"]
+    
     # --- age class carbon densities, excl forestry
     pm_carbon_density_ac  <- readGDX(gdx, "pm_carbon_density_ac")[, years, ]
 
@@ -190,7 +193,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
       fm_carbon_density       <- readGDX(gdx, "fm_carbon_density")[, years, ]
 
       # TODO @Kristine there is an incongruity between the old version of emisCO2 and the static realization
-      pasture[, , "soilc"]  <- fm_carbon_density[, , "past"][, , "soilc"]
+      pasture[, , "soilc"]    <- fm_carbon_density[, , "past"][, , "soilc"]
       urban[, , "soilc"]      <- fm_carbon_density[, , "urban"][, , "soilc"]
       primforest[, , "soilc"] <- fm_carbon_density[, , "primforest"][, , "soilc"]
 
@@ -279,12 +282,6 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
 
     .grossEmissionsHelper <- function(densityMtC, reductionMha, harvestMha = NULL, degradMha = NULL) {
 
-      magclass::where(reductionMha - harvestMha < 0)
-      min(reductionMha - harvestMha)
-
-      bools <- reductionMha - harvestMha < 0
-      reductionMha[bools] - harvestMha[bools]
-
       deforMha <- reductionMha
       if (!is.null(harvestMha)) {
         deforMha <- deforMha - harvestMha
@@ -352,7 +349,6 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     harvestMha <- add_dimension(harvestMha, dim = 3.1, add = "land", nm = "forestry_plant")
     harvestMha <- add_columns(harvestMha, addnm = "forestry_aff", dim = "land", fill = 0)
     harvestMha <- add_columns(harvestMha, addnm = "forestry_ndc", dim = "land", fill = 0)
-
     
     emisPlantations <- .grossEmissionsHelper(densityMtC    = densityMtC,
                                              reductionMha  = reductionMha,

--- a/R/emisCO2.R
+++ b/R/emisCO2.R
@@ -24,7 +24,7 @@
 #' @param lowpass number of lowpass filter iterations (default = 3)
 #' @return CO2 emissions as MAgPIE object (unit depends on \code{unit})
 #' @author Florian Humpenoeder, Michael Crawford
-#' @importFrom magclass dimSums add_dimension getSets getCells getNames add_columns 
+#' @importFrom magclass dimSums add_dimension getSets getCells getNames add_columns
 #'  collapseNames collapseDim nyears getYears setYears getItems new.magpie as.magpie
 #' @importFrom gdx readGDX
 #' @examples
@@ -108,7 +108,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
                   secdforest    = secdforest,
                   other         = other,
                   forestry      = forestry)
-                  # croptreecover = croptreecover)
+    # croptreecover = croptreecover)
 
     return(areas)
 
@@ -135,7 +135,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     pasture           <- fm_carbon_density[, , "past"]
     urban             <- fm_carbon_density[, , "urban"]
     primforest        <- fm_carbon_density[, , "primforest"]
-    
+
     # --- age class carbon densities, excl forestry
     pm_carbon_density_ac  <- readGDX(gdx, "pm_carbon_density_ac")[, years, ]
 
@@ -188,7 +188,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
       i59_subsoilc_density <- readGDX(gdx, "i59_subsoilc_density")[, years, ]
 
       cropland[, , "soilc"] <- i59_topsoilc_density + i59_subsoilc_density
-      
+
       # --- all other types
       fm_carbon_density       <- readGDX(gdx, "fm_carbon_density")[, years, ]
 
@@ -200,13 +200,13 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
       # croptreecover is mapped to secdforest
       # croptreecoverSOM <- collapseDim(fm_carbon_density[, , "secdforest"][, , "soilc"], dim = "land")
       # croptreecover <- .addSOM(croptreecover, croptreecoverSOM)
-      
+
       secdforestSOM <- collapseDim(fm_carbon_density[, , "secdforest"][, , "soilc"], dim = "land")
       secdforest    <- .addSOM(secdforest, secdforestSOM)
-      
+
       otherSOM <- collapseDim(fm_carbon_density[, , "other"][, , "soilc"], dim = "land")
       other    <- .addSOM(other, otherSOM)
-      
+
       forestrySOM <- collapseDim(fm_carbon_density[, , "forestry"][, , "soilc"], dim = "land")
       forestry    <- .addSOM(forestry, forestrySOM)
 
@@ -219,7 +219,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
                 secdforest    = secdforest,
                 other         = other,
                 forestry      = forestry))
-                # croptreecover = croptreecover))
+    # croptreecover = croptreecover))
   }
 
   ###
@@ -346,13 +346,13 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     reductionMha <- readGDX(gdx, "ov32_land_reduction", select = list(type = "level"), react = "silent")
     getSets(reductionMha)["d3.1"] <- "land"
     getNames(reductionMha, dim = 1) <- c("forestry_aff", "forestry_ndc", "forestry_plant")
-        
+
     # Only plantations are subject to harvesting
     harvestMha <- readGDX(gdx, "ov32_hvarea_forestry", select = list(type = "level"), react = "silent")
     harvestMha <- add_dimension(harvestMha, dim = 3.1, add = "land", nm = "forestry_plant")
     harvestMha <- add_columns(harvestMha, addnm = "forestry_aff", dim = "land", fill = 0)
     harvestMha <- add_columns(harvestMha, addnm = "forestry_ndc", dim = "land", fill = 0)
-    
+
     emisPlantations <- .grossEmissionsHelper(densityMtC    = densityMtC,
                                              reductionMha  = reductionMha,
                                              harvestMha    = harvestMha)
@@ -362,7 +362,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     # areaBeforeOptimMha <- readGDX(gdx, "p29_treecover", react = "silent")
     # areaAfterOptimMha  <- areas$croptreecover
     # reductionMha       <- .change_ac(areaBeforeOptimMha, areaAfterOptimMha, mode = "reduction")
-    # 
+    #
     # emisCroptreecover <- .grossEmissionsHelper(densityMtC   = densityMtC,
     #                                            reductionMha = reductionMha)
 
@@ -371,7 +371,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
                                emisSecdforest    = emisSecdforest,
                                emisOther         = emisOther,
                                emisPlantations   = emisPlantations)
-                               # emisCroptreecover = emisCroptreecover)
+    # emisCroptreecover = emisCroptreecover)
 
     emisDeforestation <- mbind(lapply(X = grossEmissionsLand, FUN = function(x) x$emisDeforMtC))
     emisHarvest       <- mbind(lapply(X = grossEmissionsLand, FUN = function(x) x$emisharvestMtC))
@@ -580,7 +580,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     # areaBeforeOptimMha <- readGDX(gdx, "p29_treecover", , react = "silent")
     # areaAfterOptimMha  <- areas$croptreecover
     # expansion <- .change_ac(areaBeforeOptimMha, areaAfterOptimMha, mode = "expansion")
-    # 
+    #
     # regrowthEmisCroptreecover <- .regrowth(densityAg = densityAg,
     #                                        area      = areaAfterOptimMha,
     #                                        expansion = expansion)
@@ -588,7 +588,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     regrowth <- mbind(regrowthEmisSecdforest,
                       regrowthEmisOther,
                       regrowthEmisForestry)
-                      # regrowthEmisCroptreecover)
+    # regrowthEmisCroptreecover)
 
     regrowth <- dimSums(regrowth, dim = "ac")
 
@@ -617,13 +617,13 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     if (any(totalEmissions - componentEmissions > 1e-06, na.rm = TRUE)) {
       stop("Inapprpopriately high residuals in main emissions in magpie4::emisCO2")
     }
-    
+
     # --- Ensure that gross emissions are all positive
     grossEmissions <- output[, , c("lu_deforestation", "lu_degrad", "lu_other_conversion", "lu_harvest")]
     if (any(grossEmissions < -1e-06, na.rm = TRUE)) {
       stop("Gross emissions are less than zero in magpie4::emisCO2")
     }
-  
+
   }
 
   ###

--- a/R/emisCO2.R
+++ b/R/emisCO2.R
@@ -391,7 +391,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
 
   ###
   # aboveground negative emissions from regrowth
-  calculateRegrowthEmissions <- function(template, areas, densities)  {
+  calculateRegrowthEmissions <- function(areas, densities)  {
 
     ###
     # Calculate expansion of ac land types in Mha over time

--- a/R/emisCO2.R
+++ b/R/emisCO2.R
@@ -169,17 +169,17 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
       primforest[, , "soilc"] <- (f59_topsoilc_density * cshare[, , "primforest"]) + i59_subsoilc_density
 
       # croptreecover is mapped to secdforest
-      # croptreecover <- .addSOM(croptreecover,
-      #                          (f59_topsoilc_density * cshare[, , "croptreecover"]) + i59_subsoilc_density)
+      # croptreecoverSOM <- (f59_topsoilc_density * cshare[, , "croptreecover"]) + i59_subsoilc_density
+      # croptreecover    <- .addSOM(croptreecover, croptreecoverSOM)
 
-      secdforest    <- .addSOM(secdforest,
-                               (f59_topsoilc_density * cshare[, , "secdforest"]) + i59_subsoilc_density)
+      secdforestSOM <- (f59_topsoilc_density * cshare[, , "secdforest"]) + i59_subsoilc_density
+      secdforest    <- .addSOM(secdforest, secdforestSOM)
 
-      other         <- .addSOM(other,
-                               (f59_topsoilc_density * cshare[, , "other"]) + i59_subsoilc_density)
+      otherSOM <- (f59_topsoilc_density * cshare[, , "other"]) + i59_subsoilc_density
+      other    <- .addSOM(other, otherSOM)
 
-      forestry      <- .addSOM(forestry,
-                               (f59_topsoilc_density * collapseNames(cshare[, , "forestry"])) + i59_subsoilc_density)
+      forestrySOM <- (f59_topsoilc_density * collapseNames(cshare[, , "forestry"])) + i59_subsoilc_density
+      forestry    <- .addSOM(forestry, forestrySOM)
 
     } else {
 
@@ -198,14 +198,17 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
       primforest[, , "soilc"] <- fm_carbon_density[, , "primforest"][, , "soilc"]
 
       # croptreecover is mapped to secdforest
-      # croptreecover <- .addSOM(croptreecover,
-      #                          collapseDim(fm_carbon_density[, , "secdforest"][, , "soilc"], dim = "land"))
-      secdforest    <- .addSOM(secdforest,
-                               collapseDim(fm_carbon_density[, , "secdforest"][, , "soilc"], dim = "land"))
-      other         <- .addSOM(other,
-                               collapseDim(fm_carbon_density[, , "other"][, , "soilc"], dim = "land"))
-      forestry      <- .addSOM(forestry,
-                               collapseDim(fm_carbon_density[, , "forestry"][, , "soilc"], dim = "land"))
+      # croptreecoverSOM <- collapseDim(fm_carbon_density[, , "secdforest"][, , "soilc"], dim = "land")
+      # croptreecover <- .addSOM(croptreecover, croptreecoverSOM)
+      
+      secdforestSOM <- collapseDim(fm_carbon_density[, , "secdforest"][, , "soilc"], dim = "land")
+      secdforest    <- .addSOM(secdforest, secdforestSOM)
+      
+      otherSOM <- collapseDim(fm_carbon_density[, , "other"][, , "soilc"], dim = "land")
+      other    <- .addSOM(other, otherSOM)
+      
+      forestrySOM <- collapseDim(fm_carbon_density[, , "forestry"][, , "soilc"], dim = "land")
+      forestry    <- .addSOM(forestry, forestrySOM)
 
     }
 

--- a/R/reportEmissions.R
+++ b/R/reportEmissions.R
@@ -30,125 +30,121 @@
 #' @md
 #'
 reportEmissions <- function(gdx, storageWood = TRUE) {
+  
   # -----------------------------------------------------------------------------------------------------------------
   # Calculate CO2 emissions from a MAgPIE .gdx file
-
+  
   # landuseChange is mostly positive (deforestation) and regrowth is mostly negative (regrowth/afforestation),
   #   but there are some cases that behave differently.
-
+  
   # landuseChange: cropland-to-pasture conversion causes negative emissions in soilc
-
+  
   # regrowth: Litter carbon can decrease in case of afforestation/regrowth because the starting
   #   level of litter carbon is always pasture litc. If pasture litc is higher than natveg
   #   litc, this results in positive emissions.
+  
   .calcCO2 <- function(.lowpass = 3, .cumulative = FALSE, .raw = FALSE, .landCarbonSink = "grassi") {
-
+    
     co2 <- emisCO2(gdx,
                    level = "regglo", unit = "gas", sum_land = FALSE, sum_cpool = FALSE,
                    lowpass = .lowpass, cumulative = .cumulative)
-
+    
     if (.landCarbonSink == "grassi") {
       # To ensure consistency with national forest inventories, we replace our estimates of indirect emissions
       # from climate change (on all MAgPIE land-use types) with the emission land-carbon sink of
       # Grassi et al. (2021), which includes only managed forest. At the moment this is default behavior.
-      climateChange <- landCarbonSink(gdx, level = "regglo", cumulative = .cumulative)
+      eClimateChange <- landCarbonSink(gdx, level = "regglo", cumulative = .cumulative)
     } else {
-      climateChange <- dimSums(co2[, , "cc"], dim = 3)
+      eClimateChange <- dimSums(co2[, , "cc"], dim = 3)
     }
-
+    
     # If cumulative, convert Mt CO2 to Gt CO2
     if (.cumulative) {
       co2 <- co2 / 1000
-      climateChange <- climateChange / 1000
+      eClimateChange <- eClimateChange / 1000
     }
-
-    landuseTotal <- dimSums(co2[, , "lu"], dim = 3)
-    total <- landuseTotal + climateChange
-
-    if (!.raw) {
-
-      landuseChange <- dimSums(co2[, , "lu_luc"], dim = 3)
-      degradation   <- dimSums(co2[, , "lu_degrad"], dim = 3)
-
-      # Emission from deforestation and other land conversion
-      deforestation <- dimSums(co2[, , "lu_deforestation"], dim = 3)
-      other_conv    <- dimSums(co2[, , "lu_other_conversion"], dim = 3)
-
-      # Update landuseChange
-      landuseChange <- landuseChange + deforestation + other_conv # Degradation is already present within deforestation
-
-      vegetation <- c("forestry_plant", "forestry_ndc", "forestry_aff", "secdforest", "other")
-      regrowth   <- collapseNames(dimSums(co2[, , "lu_regrowth"][, , vegetation], dim = "c_pools"), collapsedim = "type")
-
-      # Above Ground / Below Ground Carbon
-      totalPools   <- collapseNames(dimSums(co2[, , "total"], dim = c("land")))
-      climatePools <- collapseNames(dimSums(co2[, , "cc"],    dim = c("land")))
-      landusePools <- collapseNames(dimSums(co2[, , "lu"],    dim = c("land")))
-
-      # Calculate wood products, if forestry module was activated and desired
-      emisWoodProducts <- carbonLTS(gdx, level = "regglo", unit = "gas", cumulative = .cumulative)[, getYears(total), ]
-
-      if (!is.null(emisWoodProducts) && storageWood) {
-
-        if (.cumulative) {
-          # Can't divide by 1000 during cumulative calc as in def runs its NULL and NULL/1000 is numeric(0)
-          emisWoodProducts <- emisWoodProducts / 1000
-        }
-
-        # All categories
-        inflow  <- collapseNames(emisWoodProducts[, , "annual_inflow"])
-        outflow <- collapseNames(emisWoodProducts[, , "annual_outflow"])
-
-        # Wood products (not including constr wood)
-        emisWood        <- collapseNames(emisWoodProducts[, , "emis_wood"])        # -1 removed in carbonLTS_IPCC.R
-        emisWoodFuel    <- collapseNames(emisWoodProducts[, , "emis_woodfuel"])    # -1 removed in carbonLTS_IPCC.R
-        emisConstrWood  <- collapseNames(emisWoodProducts[, , "emis_constr_wood"]) # -1 removed in carbonLTS_IPCC.R
-
-        # Purely industrial roundwood
-        emisWoodInflow  <- collapseNames(emisWoodProducts[, , "wood_inflow"])
-        emisWoodOutflow <- collapseNames(emisWoodProducts[, , "wood_outflow"])
-        emisWoodNet     <- collapseNames(emisWoodInflow + emisWoodOutflow) # inflow is negative
-
-        # Building materials
-        emisBuildingInflow  <- collapseNames(emisWoodProducts[, , "building_inflow"])
-        emisBuildingOutflow <- collapseNames(emisWoodProducts[, , "building_outflow"])
-        emisBuildingNet     <- collapseNames(emisBuildingInflow + emisBuildingOutflow) # inflow is negative
-
-        # Sum of net emissions from industrial roundwood and building material
-        storage <- emisWoodNet + emisBuildingNet
-
-        # Total emissions from wood harvest
-        wood <- emisWoodFuel + storage  # emisWood is already accounted for in storage!
-
-        # Recalculate top-level categories
-        landuseChange <- landuseChange - (emisWood + emisWoodFuel + emisConstrWood) # Subtract all wood-related emissions
-        landuseTotal  <- landuseChange + dimSums(regrowth, dim = 3) + wood # Add wood-related emissions and removals
-        total <- landuseTotal + climateChange
-
-        # Consistency check
-        if (abs(sum(landuseTotal -
-                    (landuseChange + dimSums(regrowth, dim = 3) + collapseNames(wood)),
-                    na.rm = TRUE)) > 0.1) {
-          warning("Emission subcategories do not add up to total! Check the code.")
-        }
-
-      } else {
-
-        wood                <- NULL
-        emisWoodFuel        <- NULL
-        storage             <- NULL
-        inflow              <- NULL
-        outflow             <- NULL
-        emisWoodNet         <- NULL
-        emisWoodInflow      <- NULL
-        emisWoodOutflow     <- NULL
-        emisBuildingNet     <- NULL
-        emisBuildingInflow  <- NULL
-        emisBuildingOutflow <- NULL
-
+    
+    eLanduseChange <- dimSums(co2[, , "lu"], dim = 3)
+    totalNetFlux   <- eLanduseChange + eClimateChange
+    
+    if (.raw) {
+      .x = list(
+        totalNetFlux   = totalNetFlux,
+        eLanduseChange = eLanduseChange,
+        eClimateChange = eClimateChange)
+      
+      return(.x)
+    }
+    
+    # Emission from deforestation, degradation, and other land conversion
+    deforestation    <- collapseNames(dimSums(co2[, , "lu_deforestation"],    dim = "c_pools"))
+    degradation      <- collapseNames(dimSums(co2[, , "lu_degrad"],           dim = "c_pools"))
+    other_conversion <- collapseNames(dimSums(co2[, , "lu_other_conversion"], dim = "c_pools"))
+    regrowth         <- collapseNames(dimSums(co2[, , "lu_regrowth"],         dim = "c_pools"))
+    
+    # TODO How does the LTS change the pools here? 
+    # Above Ground / Below Ground Carbon
+    totalPools   <- collapseNames(dimSums(co2[, , "total"], dim = "land"))
+    climatePools <- collapseNames(dimSums(co2[, , "cc"],    dim = "land"))
+    landusePools <- collapseNames(dimSums(co2[, , "lu"],    dim = "land"))
+    
+    # Calculate wood products, if forestry module was activated and desired
+    emisWoodProducts <- carbonLTS(gdx, level = "regglo", unit = "gas", cumulative = .cumulative)[, getYears(totalNetFlux), ]
+    
+    if (!is.null(emisWoodProducts) && storageWood) {
+      
+      if (.cumulative) {
+        # Can't divide by 1000 during cumulative calc as in def runs its NULL and NULL/1000 is numeric(0)
+        emisWoodProducts <- emisWoodProducts / 1000
       }
+      
+      # All categories
+      inflow  <- collapseNames(emisWoodProducts[, , "annual_inflow"])
+      outflow <- collapseNames(emisWoodProducts[, , "annual_outflow"])
+      
+      # Wood products (not including constr wood)
+      emisWood        <- collapseNames(emisWoodProducts[, , "emis_wood"])        # -1 removed in carbonLTS_IPCC.R
+      emisWoodFuel    <- collapseNames(emisWoodProducts[, , "emis_woodfuel"])    # -1 removed in carbonLTS_IPCC.R
+      emisConstrWood  <- collapseNames(emisWoodProducts[, , "emis_constr_wood"]) # -1 removed in carbonLTS_IPCC.R
+      
+      # Purely industrial roundwood
+      emisWoodInflow  <- collapseNames(emisWoodProducts[, , "wood_inflow"]) # inflow is negative emissions
+      emisWoodOutflow <- collapseNames(emisWoodProducts[, , "wood_outflow"])
+      emisWoodNet     <- collapseNames(emisWoodInflow + emisWoodOutflow) 
+      
+      # Building materials
+      emisBuildingInflow  <- collapseNames(emisWoodProducts[, , "building_inflow"]) # inflow is negative emissions
+      emisBuildingOutflow <- collapseNames(emisWoodProducts[, , "building_outflow"])
+      emisBuildingNet     <- collapseNames(emisBuildingInflow + emisBuildingOutflow) 
+      
+      # Sum of net emissions from industrial roundwood and building material
+      storage <- emisWoodNet + emisBuildingNet
+      
+      # Total emissions from wood harvest
+      wood <- emisWoodFuel + storage # emisWood is already accounted for in storage
+      
+      # remove negative emissions from long-term storage of wood products
+      harvestOld <- dimSums(co2[, , "lu_harvest"], dim = 3)
+      harvestNew <- harvestOld - (emisWoodInflow + emisBuildingInflow)
+      eLanduseChange <- eLanduseChange - harvestOld + harvestNew
+      totalNetFlux   <- eLanduseChange + eClimateChange
+      
+    } else {
+      
+      wood                <- NULL
+      emisWoodFuel        <- NULL
+      storage             <- NULL
+      inflow              <- NULL
+      outflow             <- NULL
+      emisWoodNet         <- NULL
+      emisWoodInflow      <- NULL
+      emisWoodOutflow     <- NULL
+      emisBuildingNet     <- NULL
+      emisBuildingInflow  <- NULL
+      emisBuildingOutflow <- NULL
+      
     }
-
+    
     # use PeatlandEmissions for reporting to exclude emissions from intact peatlands
     # No lowpass filter applied to peatland emissions
     peatland <- PeatlandEmissions(gdx, cumulative = .cumulative, unit = "gas", level = "regglo", intact = FALSE)
@@ -157,209 +153,231 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     } else {
       peatland <- setNames(dimSums(peatland[, , c("co2", "doc")], dim = 3), "peatland")
     }
-
-    if (!is.null(peatland)) {
-      if (.cumulative) {
-        peatland <- peatland / 1000
-      }
-
-      total        <- total + peatland
-      landuseTotal <- landuseTotal + peatland
+    
+    if (.cumulative) {
+      peatland <- peatland / 1000
     }
-
-    # Generate return list
-    if (.raw) {
-      .x <- list(
-        total         = total,
-        landuseTotal  = landuseTotal,
-        climateChange = climateChange
-      )
-
-    } else {
-      .x <- list(
-        total                      = total,
-        landuseTotal               = landuseTotal,
-        climateChange              = climateChange,
-        landuseChange              = landuseChange,
-        deforestation              = deforestation,
-        other_conv                 = other_conv,
-        degradation                = degradation,
-        totalRegrowth              = dimSums(regrowth, dim = 3),
-        regrowthAffCO2Price        = collapseNames(regrowth[, , "forestry_aff"]),
-        regrowthAffNPI_NDC         = collapseNames(regrowth[, , "forestry_ndc"]),
-        regrowthPlantations        = collapseNames(regrowth[, , "forestry_plant"]),
-        regrowthSecondaryForests   = collapseNames(regrowth[, , "secdforest"]),
-        regrowthOther              = collapseNames(regrowth[, , "other"]),
-        wood                       = wood,
-        emisWoodFuel               = emisWoodFuel,
-        storage                    = storage,
-        # inflow                    = inflow,
-        # outlow                    = outflow,
-        emisWoodNet                = emisWoodNet,
-        emisWoodInflow             = emisWoodInflow,
-        emisWoodOutflow            = emisWoodOutflow,
-        emisBuildingNet            = emisBuildingNet,
-        emisBuildingInflow         = emisBuildingInflow,
-        emisBuildingOutflow        = emisBuildingOutflow,
-        peatland                   = peatland,
-        totalPools                 = totalPools,
-        climatePools               = climatePools,
-        landusePools               = landusePools
-      )
-    }
-
+    
+    totalNetFlux   <- totalNetFlux + peatland
+    eLanduseChange <- eLanduseChange + peatland
+    
+    # generate return list
+    .x <- list(
+      totalNetFlux               = totalNetFlux,
+      eLanduseChange             = eLanduseChange,
+      eClimateChange             = eClimateChange,
+      deforestation              = deforestation,
+      other_conversion           = other_conversion,
+      degradation                = degradation,
+      regrowth                   = regrowth,
+      wood                       = wood,
+      emisWoodFuel               = emisWoodFuel,
+      storage                    = storage,
+      # inflow                    = inflow,
+      # outlow                    = outflow,
+      emisWoodNet                = emisWoodNet,
+      emisWoodInflow             = emisWoodInflow,
+      emisWoodOutflow            = emisWoodOutflow,
+      emisBuildingNet            = emisBuildingNet,
+      emisBuildingInflow         = emisBuildingInflow,
+      emisBuildingOutflow        = emisBuildingOutflow,
+      peatland                   = peatland,
+      totalPools                 = totalPools,
+      climatePools               = climatePools,
+      landusePools               = landusePools
+    )
+    
     return(.x)
   }
-
-
+  
+  # -----------------------------------------------------------------------------------------------------------------
+  # Generate reports
+  
+  emissionsReport <- NULL
+  
   # -----------------------------------------------------------------------------------------------------------------
   # Yearly CO2 emissions, lowpass = 3
-
+  
   yearlyCO2 <- .calcCO2(.lowpass = 3, .cumulative = FALSE)
-
+  
   # nolint start
-  emissionsReport <- with(yearlyCO2,
-                          mbind(
-                            setNames(total,                     "Emissions|CO2|Land (Mt CO2/yr)"), # all human-induced land-related CO2 emissions
-                            setNames(landuseTotal,              "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
-                            setNames(climateChange,             "Emissions|CO2|Land|+|Indirect (Mt CO2/yr)"), # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
-                            setNames(landuseChange,             "Emissions|CO2|Land|Land-use Change|+|Gross LUC (Mt CO2/yr)"), # land-use change
-                            setNames(deforestation,             "Emissions|CO2|Land|Land-use Change|Gross LUC|+|Deforestation (Mt CO2/yr)"), # land-use change
-                            setNames(degradation,               "Emissions|CO2|Land|Land-use Change|Gross LUC|Deforestation|+|Forest Degradation (Mt CO2/yr)"), # forest degradation
-                            setNames(other_conv,                "Emissions|CO2|Land|Land-use Change|Gross LUC|+|Other land conversion (Mt CO2/yr)"), # land-use change
-                            setNames(totalRegrowth,             "Emissions|CO2|Land|Land-use Change|+|Regrowth (Mt CO2/yr)"), # regrowth of vegetation
-                            setNames(regrowthAffCO2Price,       "Emissions|CO2|Land|Land-use Change|Regrowth|CO2-price AR (Mt CO2/yr)"), # regrowth of vegetation
-                            setNames(regrowthAffNPI_NDC,        "Emissions|CO2|Land|Land-use Change|Regrowth|NPI_NDC AR (Mt CO2/yr)"), # regrowth of vegetation
-                            setNames(regrowthPlantations,       "Emissions|CO2|Land|Land-use Change|Regrowth|Timber Plantations (Mt CO2/yr)"), # regrowth of vegetation
-                            setNames(regrowthSecondaryForests,  "Emissions|CO2|Land|Land-use Change|Regrowth|Secondary Forest (Mt CO2/yr)"), # regrowth of vegetation
-                            setNames(regrowthOther,             "Emissions|CO2|Land|Land-use Change|Regrowth|Other Land (Mt CO2/yr)"), # regrowth of vegetation
-                            setNames(peatland,                  "Emissions|CO2|Land|Land-use Change|+|Peatland (Mt CO2/yr)"),
-                            # setNames(totalPools,                paste0("Emissions|CO2|Land|Land-use Change|++|", getNames(totalPools), " (Mt CO2/yr)"))
-                            setNames(landusePools,              paste0("Emissions|CO2|Land|Land-use Change|++|", getNames(landusePools), " (Mt CO2/yr)"))
-                            # setNames(climatePools,              paste0("Emissions|CO2|Land|Land-use Change|++|", getNames(climatePools), " (Mt CO2/yr)"))
-
-                          )
-  )
-
+  emissionsReport <- with(yearlyCO2, mbind(
+    emissionsReport, 
+    
+    setNames(totalNetFlux,                        "Emissions|CO2|Land (Mt CO2/yr)"), # all human-induced land-related CO2 emissions
+    setNames(eClimateChange,                      "Emissions|CO2|Land|+|Indirect (Mt CO2/yr)"), # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
+    setNames(eLanduseChange,                      "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
+    
+    # Gross emissions - Deforestation
+    setNames(dimSums(deforestation, dim = 3),     "Emissions|CO2|Land|Land-use Change|+|Deforestation (Mt CO2/yr)"),
+    setNames(deforestation[, , "primforest"],     "Emissions|CO2|Land|Land-use Change|Deforestation|+|Primary forests (Mt CO2/yr)"),
+    setNames(deforestation[, , "secdforest"],     "Emissions|CO2|Land|Land-use Change|Deforestation|+|Secondary forests (Mt CO2/yr)"),
+    setNames(deforestation[, , "forestry_plant"], "Emissions|CO2|Land|Land-use Change|Deforestation|+|Forestry plantations (Mt CO2/yr)"),
+    
+    # Gross emissions - Degradataion
+    setNames(dimSums(degradation, dim = 3),       "Emissions|CO2|Land|Land-use Change|+|Forest degradation (Mt CO2/yr)"),
+    setNames(degradation[, , "primforest"],       "Emissions|CO2|Land|Land-use Change|Forest degradation|+|Primary forests (Mt CO2/yr)"),
+    setNames(degradation[, , "secdforest"],       "Emissions|CO2|Land|Land-use Change|Forest degradation|+|Secondary forests (Mt CO2/yr)"),
+    
+    # Gross emissions - Other conversion
+    setNames(other_conversion[, , "other"],       "Emissions|CO2|Land|Land-use Change|+|Other land conversion (Mt CO2/yr)"),
+    
+    # Regrowth
+    setNames(dimSums(regrowth, dim = 3),          "Emissions|CO2|Land|Land-use Change|+|Regrowth (Mt CO2/yr)"),
+    setNames(regrowth[, , "forestry_aff"],        "Emissions|CO2|Land|Land-use Change|Regrowth|+|CO2-price AR (Mt CO2/yr)"),
+    setNames(regrowth[, , "forestry_ndc"],        "Emissions|CO2|Land|Land-use Change|Regrowth|+|NPI_NDC AR (Mt CO2/yr)"),
+    setNames(regrowth[, , "forestry_plant"],      "Emissions|CO2|Land|Land-use Change|Regrowth|+|Timber Plantations (Mt CO2/yr)"),
+    setNames(regrowth[, , "secdforest"],          "Emissions|CO2|Land|Land-use Change|Regrowth|+|Secondary Forest (Mt CO2/yr)"),
+    setNames(regrowth[, , "other"],               "Emissions|CO2|Land|Land-use Change|Regrowth|+|Other Land (Mt CO2/yr)"),
+    
+    # Gross emissions - Peatland
+    setNames(peatland,                            "Emissions|CO2|Land|Land-use Change|+|Peatland (Mt CO2/yr)"),
+    
+    # Carbon pools
+    setNames(totalPools,                           paste0("Emissions|CO2|Land|++|", getNames(totalPools), " (Mt CO2/yr)")),
+    setNames(climatePools,                         paste0("Emissions|CO2|Land|Indirect|++|", getNames(climatePools), " (Mt CO2/yr)")),
+    setNames(landusePools,                         paste0("Emissions|CO2|Land|Land-use Change|++|", getNames(landusePools), " (Mt CO2/yr)"))
+    
+  ))
+  
   # Only attempt to append wood-related reports if the forestry module was activated
   if (!is.null(yearlyCO2$wood)) {
-    emissionsReport <- with(yearlyCO2,
-                            mbind(
-                              emissionsReport,
-                              setNames(wood,                      "Emissions|CO2|Land|Land-use Change|+|Wood Harvest (Mt CO2/yr)"),
-                              setNames(emisWoodFuel,              "Emissions|CO2|Land|Land-use Change|Wood Harvest|Short Lived Products (Mt CO2/yr)"),
-                              setNames(storage,                   "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage (Mt CO2/yr)"), # carbon stored in wood products + release from wood products
-                              # setNames(inflow,                  "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Inflow (Mt CO2/yr)"), # carbon stored in wood products
-                              # setNames(outlow,                  "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Outflow (Mt CO2/yr)"), # slow release from wood products
-                              setNames(emisWoodNet,               "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Industrial roundwood (Mt CO2/yr)"), # carbon stored in Industrial roundwood + release from Industrial roundwood
-                              setNames(emisWoodInflow,            "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Inflow (Mt CO2/yr)"), # carbon stored in Industrial roundwood
-                              setNames(emisWoodOutflow,           "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Outflow (Mt CO2/yr)"), # slow release from Industrial roundwood
-                              setNames(emisBuildingNet,           "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Buildings (Mt CO2/yr)"), # carbon stored in wood buildings + release from wood buildings
-                              setNames(emisBuildingInflow,        "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Mt CO2/yr)"), # carbon stored in wood buildings
-                              setNames(emisBuildingOutflow,       "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Mt CO2/yr)") # slow release from wood buildings
-                            )
-    )
+    
+    emissionsReport <- with(yearlyCO2, mbind(
+      emissionsReport,
+      
+      setNames(emisWoodFuel,        "Emissions|CO2|Land|Land-use Change|Wood Harvest|++|Short Lived Products (Mt CO2/yr)"),
+      setNames(storage,             "Emissions|CO2|Land|Land-use Change|Wood Harvest|++|Storage (Mt CO2/yr)"), # carbon stored in wood products + release from wood products
+      # setNames(inflow,            "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Inflow (Mt CO2/yr)"), # carbon stored in wood products
+      # setNames(outlow,            "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Outflow (Mt CO2/yr)"), # slow release from wood products
+      setNames(emisWoodNet,         "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Industrial roundwood (Mt CO2/yr)"), # carbon stored in Industrial roundwood + release from Industrial roundwood
+      setNames(emisWoodInflow,      "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Inflow (Mt CO2/yr)"), # carbon stored in Industrial roundwood
+      setNames(emisWoodOutflow,     "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Outflow (Mt CO2/yr)"), # slow release from Industrial roundwood
+      setNames(emisBuildingNet,     "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Buildings (Mt CO2/yr)"), # carbon stored in wood buildings + release from wood buildings
+      setNames(emisBuildingInflow,  "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Mt CO2/yr)"), # carbon stored in wood buildings
+      setNames(emisBuildingOutflow, "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Mt CO2/yr)") # slow release from wood buildings
+    ))
+    
   }
   # nolint end
-
-
+  
   # -----------------------------------------------------------------------------------------------------------------
   # RAW yearly CO2 emissions, lowpass = 0
-
+  
   rawYearlyCO2 <- .calcCO2(.lowpass = 0, .cumulative = FALSE, .raw = TRUE)
-
+  
   # nolint start
-  emissionsReport <- with(rawYearlyCO2,
-                          mbind(
-                            emissionsReport,
-                            setNames(total,         "Emissions|CO2|Land RAW (Mt CO2/yr)"),
-                            setNames(landuseTotal,  "Emissions|CO2|Land RAW|+|Land-use Change RAW (Mt CO2/yr)"),
-                            setNames(climateChange, "Emissions|CO2|Land RAW|+|Indirect RAW (Mt CO2/yr)")
-                          )
-  )
+  emissionsReport <- with(rawYearlyCO2, mbind(
+    emissionsReport,
+    
+    setNames(totalNetFlux,   "Emissions|CO2|Land RAW (Mt CO2/yr)"),
+    setNames(eLanduseChange, "Emissions|CO2|Land RAW|+|Land-use Change RAW (Mt CO2/yr)"),
+    setNames(eClimateChange, "Emissions|CO2|Land RAW|+|Indirect RAW (Mt CO2/yr)")
+  ))
   # nolint end
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # Cumulative CO2 emissions, lowpass = 3
-
+  
   cumulativeCO2 <- .calcCO2(.lowpass = 3, .cumulative = TRUE)
-
+  
   # nolint start
-  emissionsReport <- with(cumulativeCO2,
-                          mbind(
-                            emissionsReport,
-                            setNames(total,                     "Emissions|CO2|Land|Cumulative (Gt CO2)"),
-                            setNames(landuseTotal,              "Emissions|CO2|Land|Cumulative|+|Land-use Change (Gt CO2)"),
-                            setNames(climateChange,             "Emissions|CO2|Land|Cumulative|+|Indirect (Gt CO2)"),
-                            setNames(landuseChange,             "Emissions|CO2|Land|Cumulative|Land-use Change|+|Gross LUC (Gt CO2)"),
-                            setNames(deforestation,             "Emissions|CO2|Land|Cumulative|Land-use Change|Gross LUC|+|Deforestation (Gt CO2)"), # land-use change
-                            setNames(other_conv,                "Emissions|CO2|Land|Cumulative|Land-use Change|Gross LUC|+|Other land conversion (Gt CO2)"), # land-use change
-                            setNames(degradation,               "Emissions|CO2|Land|Cumulative|Land-use Change|Gross LUC|+|Forest Degradation (Gt CO2)"),
-                            setNames(totalRegrowth,             "Emissions|CO2|Land|Cumulative|Land-use Change|+|Regrowth (Gt CO2)"),
-                            setNames(regrowthAffCO2Price,       "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|CO2-price AR (Gt CO2)"),
-                            setNames(regrowthAffNPI_NDC,        "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|NPI_NDC AR (Gt CO2)"),
-                            setNames(regrowthPlantations,       "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|Timber Plantations (Gt CO2)"),
-                            setNames(regrowthSecondaryForests,  "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|Secondary Forest (Gt CO2)"),
-                            setNames(regrowthOther,             "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|Other Land (Gt CO2)"),
-                            setNames(peatland,                  "Emissions|CO2|Land|Cumulative|Land-use Change|+|Peatland (Gt CO2)")
-                          )
-  )
-
+  emissionsReport <- with(cumulativeCO2, mbind(
+    emissionsReport,
+    
+    setNames(totalNetFlux,                        "Emissions|CO2|Land|Cumulative (Gt CO2)"), # all human-induced land-related CO2 emissions
+    setNames(eClimateChange,                      "Emissions|CO2|Land|Cumulative|+|Indirect (Gt CO2)"), # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
+    setNames(eLanduseChange,                      "Emissions|CO2|Land|Cumulative|+|Land-use Change (Gt CO2)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
+    
+    # Gross emissions - Deforestation
+    setNames(dimSums(deforestation, dim = 3),     "Emissions|CO2|Land|Cumulative|Land-use Change|+|Deforestation (Gt CO2)"),
+    setNames(deforestation[, , "primforest"],     "Emissions|CO2|Land|Cumulative|Land-use Change|Deforestation|+|Primary forests (Gt CO2)"),
+    setNames(deforestation[, , "secdforest"],     "Emissions|CO2|Land|Cumulative|Land-use Change|Deforestation|+|Secondary forests (Gt CO2)"),
+    setNames(deforestation[, , "forestry_plant"], "Emissions|CO2|Land|Cumulative|Land-use Change|Deforestation|+|Forestry plantations (Gt CO2)"),
+    
+    # Gross emissions - Degradataion
+    setNames(dimSums(degradation, dim = 3),       "Emissions|CO2|Land|Cumulative|Land-use Change|+|Forest degradation (Gt CO2)"),
+    setNames(degradation[, , "primforest"],       "Emissions|CO2|Land|Cumulative|Land-use Change|Forest degradation|+|Primary forests (Gt CO2)"),
+    setNames(degradation[, , "secdforest"],       "Emissions|CO2|Land|Cumulative|Land-use Change|Forest degradation|+|Secondary forests (Gt CO2)"),
+    
+    # Gross emissions - Other conversion
+    setNames(other_conversion[, , "other"],       "Emissions|CO2|Land|Cumulative|Land-use Change|+|Other land conversion (Gt CO2)"),
+    
+    # Regrowth
+    setNames(dimSums(regrowth, dim = 3),          "Emissions|CO2|Land|Cumulative|Land-use Change|+|Regrowth (Gt CO2)"),
+    setNames(regrowth[, , "forestry_aff"],        "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|+|CO2-price AR (Gt CO2)"),
+    setNames(regrowth[, , "forestry_ndc"],        "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|+|NPI_NDC AR (Gt CO2)"),
+    setNames(regrowth[, , "forestry_plant"],      "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|+|Timber Plantations (Gt CO2)"),
+    setNames(regrowth[, , "secdforest"],          "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|+|Secondary Forest (Gt CO2)"),
+    setNames(regrowth[, , "other"],               "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|+|Other Land (Gt CO2)"),
+    
+    # Gross emissions - Peatland
+    setNames(peatland,                            "Emissions|CO2|Land|Cumulative|Land-use Change|+|Peatland (Gt CO2)"),
+    
+    # Carbon pools
+    setNames(totalPools,                          paste0("Emissions|CO2|Land|Cumulative|++|", getNames(totalPools), " (Gt CO2)")),
+    setNames(climatePools,                        paste0("Emissions|CO2|Land|Cumulative|Indirect|++|", getNames(climatePools), " (Gt CO2)")),
+    setNames(landusePools,                        paste0("Emissions|CO2|Land|Cumulative|Land-use Change|++|", getNames(landusePools), " (Gt CO2)"))
+    
+  ))
+  
+  # Only attempt to append wood-related reports if the forestry module was activated
   if (!is.null(cumulativeCO2$wood)) {
-    emissionsReport <- with(cumulativeCO2,
-                            mbind(
-                              emissionsReport,
-                              setNames(wood,                      "Emissions|CO2|Land|Cumulative|Land-use Change|+|Wood Harvest (Gt CO2)"),
-                              setNames(emisWoodFuel,              "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Short Lived Products (Gt CO2)"),
-                              setNames(storage,                   "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage (Gt CO2)"),
-                              # setNames(inflow,                  "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Inflow (Gt CO2)"),
-                              # setNames(outlow,                  "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Outflow (Gt CO2)"),
-                              setNames(emisWoodNet,               "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|+|Industrial roundwood (Gt CO2)"),
-                              setNames(emisWoodInflow,            "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Inflow (Gt CO2)"),
-                              setNames(emisWoodOutflow,           "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Outflow (Gt CO2)"),
-                              setNames(emisBuildingNet,           "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|+|Buildings (Gt CO2)"),
-                              setNames(emisBuildingInflow,        "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Gt CO2)"),
-                              setNames(emisBuildingOutflow,       "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Gt CO2)")
-                            )
-    )
+    
+    emissionsReport <- with(cumulativeCO2, mbind(
+      emissionsReport,
+      
+      setNames(emisWoodFuel,        "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|++|Short Lived Products (Gt CO2)"),
+      setNames(storage,             "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|++|Storage (Gt CO2)"), # carbon stored in wood products + release from wood products
+      # setNames(inflow,            "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Inflow (Mt CO2/yr)"), # carbon stored in wood products
+      # setNames(outlow,            "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Outflow (Mt CO2/yr)"), # slow release from wood products
+      setNames(emisWoodNet,         "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|+|Industrial roundwood (Gt CO2)"), # carbon stored in Industrial roundwood + release from Industrial roundwood
+      setNames(emisWoodInflow,      "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Inflow (Gt CO2)"), # carbon stored in Industrial roundwood
+      setNames(emisWoodOutflow,     "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Industrial roundwood|Outflow (Gt CO2)"), # slow release from Industrial roundwood
+      setNames(emisBuildingNet,     "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|+|Buildings (Gt CO2)"), # carbon stored in wood buildings + release from wood buildings
+      setNames(emisBuildingInflow,  "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Gt CO2)"), # carbon stored in wood buildings
+      setNames(emisBuildingOutflow, "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Gt CO2)") # slow release from wood buildings
+    ))
+    
   }
   # nolint end
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # Calculated indirect emissions from land-use change from a .gdx file
-
+  
   .calcLandCarbonSink <- function(.lowpass = 3, .cumulative = FALSE) {
+    
     # Estimate of land-carbon sink from LPJmL
     co2 <- emisCO2(gdx,
                    level = "regglo", unit = "gas", sum_land = FALSE, sum_cpool = FALSE,
                    lowpass = .lowpass, cumulative = .cumulative)
-
+    
     # Estimate of land-carbon sink from LPJmL
     LPJmlLCS <- co2[, , "cc", drop = TRUE]
     LPJmlLCS <- dimSums(LPJmlLCS, dim = 3.2) # Sum above- and belowground carbon
-
+    
     # Estimate of land-carbon sink from Grassi et al. (2021)
     grassiLandCarbonSink <- landCarbonSink(gdx, level = "regglo", cumulative = .cumulative)
-
+    
     # If cumulative, convert Mt CO2 to Gt CO2
     if (.cumulative) {
       LPJmlLCS  <- LPJmlLCS / 1000
       grassiLandCarbonSink <- grassiLandCarbonSink / 1000
     }
-
+    
     # Managed land summation groupings
     managedAg     <- c("crop", "past")
     managedForest <- c("secdforest", "forestry_aff", "forestry_ndc", "forestry_plant")
     managedLand   <- c(managedAg, managedForest, "urban")
-
+    
     # Unmanaged land summation groupings
     unmanagedLand <- c("primforest", "other")
-
+    
     # Total includes urban land
     totalLandCarbonSink <- c(managedLand, unmanagedLand)
-
+    
     .x <- list(grassiLandCarbonSink       = grassiLandCarbonSink,
                LPJmlLandCarbonSink        = dimSums(LPJmlLCS[, , totalLandCarbonSink], dim = 3),
                managedLand                = dimSums(LPJmlLCS[, , managedLand], dim = 3),
@@ -376,93 +394,90 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
                unmanagedLandPrimForest    = LPJmlLCS[, , "primforest", drop = TRUE],
                unmanagedLandOther         = LPJmlLCS[, , "other", drop = TRUE]
     )
-
+    
     return(.x)
   }
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # Yearly indirect CO2 emissions from land-use change (land-carbon sink) reporting
-
+  
   landCarbonSink <- .calcLandCarbonSink()
-
+  
   # nolint start
-  emissionsReport <- with(landCarbonSink,
-                          mbind(
-                            emissionsReport,
-                            setNames(grassiLandCarbonSink,       "Emissions|CO2|Land Carbon Sink|Grassi|Managed Land|Managed Forest (Mt CO2/yr)"),
-                            setNames(LPJmlLandCarbonSink,        "Emissions|CO2|Land Carbon Sink|LPJmL (Mt CO2/yr)"),
-                            setNames(managedLand,                "Emissions|CO2|Land Carbon Sink|LPJmL|+|Managed Land (Mt CO2/yr)"),
-                            setNames(managedAg,                  "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|+|Agricultural Land (Mt CO2/yr)"),
-                            setNames(managedAgCrop,              "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Agricultural land|+|Cropland (Mt CO2/yr)"),
-                            setNames(managedAgPast,              "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Agricultural land|+|Pasture (Mt CO2/yr)"),
-                            setNames(managedForest,              "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|+|Managed Forest (Mt CO2/yr)"),
-                            setNames(managedForestSecdForest,    "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Managed Forest|+|Secondary Forest (Mt CO2/yr)"),
-                            setNames(managedForestForestryAff,   "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Managed Forest|+|CO2-price AR (Mt CO2/yr)"),
-                            setNames(managedForestForestryNDC,   "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Managed Forest|+|NPI_NDC AR (Mt CO2/yr)"),
-                            setNames(managedForestForestryPlant, "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Managed Forest|+|Timber Plantations (Mt CO2/yr)"),
-                            setNames(managedUrban,               "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|+|Urban Land (Mt CO2/yr)"),
-                            setNames(unmanagedLand,              "Emissions|CO2|Land Carbon Sink|LPJmL|+|Unmanaged Land (Mt CO2/yr)"),
-                            setNames(unmanagedLandPrimForest,    "Emissions|CO2|Land Carbon Sink|LPJmL|Unmanaged Land|+|Primary Forest (Mt CO2/yr)"),
-                            setNames(unmanagedLandOther,         "Emissions|CO2|Land Carbon Sink|LPJmL|Unmanaged Land|+|Other Land (Mt CO2/yr)")
-                          )
-  )
+  emissionsReport <- with(landCarbonSink, mbind(
+    emissionsReport,
+    
+    setNames(grassiLandCarbonSink,       "Emissions|CO2|Land Carbon Sink|Grassi|Managed Land|Managed Forest (Mt CO2/yr)"),
+    setNames(LPJmlLandCarbonSink,        "Emissions|CO2|Land Carbon Sink|LPJmL (Mt CO2/yr)"),
+    setNames(managedLand,                "Emissions|CO2|Land Carbon Sink|LPJmL|+|Managed Land (Mt CO2/yr)"),
+    setNames(managedAg,                  "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|+|Agricultural Land (Mt CO2/yr)"),
+    setNames(managedAgCrop,              "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Agricultural land|+|Cropland (Mt CO2/yr)"),
+    setNames(managedAgPast,              "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Agricultural land|+|Pasture (Mt CO2/yr)"),
+    setNames(managedForest,              "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|+|Managed Forest (Mt CO2/yr)"),
+    setNames(managedForestSecdForest,    "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Managed Forest|+|Secondary Forest (Mt CO2/yr)"),
+    setNames(managedForestForestryAff,   "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Managed Forest|+|CO2-price AR (Mt CO2/yr)"),
+    setNames(managedForestForestryNDC,   "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Managed Forest|+|NPI_NDC AR (Mt CO2/yr)"),
+    setNames(managedForestForestryPlant, "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|Managed Forest|+|Timber Plantations (Mt CO2/yr)"),
+    setNames(managedUrban,               "Emissions|CO2|Land Carbon Sink|LPJmL|Managed Land|+|Urban Land (Mt CO2/yr)"),
+    setNames(unmanagedLand,              "Emissions|CO2|Land Carbon Sink|LPJmL|+|Unmanaged Land (Mt CO2/yr)"),
+    setNames(unmanagedLandPrimForest,    "Emissions|CO2|Land Carbon Sink|LPJmL|Unmanaged Land|+|Primary Forest (Mt CO2/yr)"),
+    setNames(unmanagedLandOther,         "Emissions|CO2|Land Carbon Sink|LPJmL|Unmanaged Land|+|Other Land (Mt CO2/yr)")
+  ))
   # nolint end
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # Cumulative indirect CO2 emissions from land-use change (land-carbon sink) reporting
-
+  
   cumulativeLandCarbonSink <- .calcLandCarbonSink(.cumulative = TRUE)
-
+  
   # nolint start
-  emissionsReport <- with(cumulativeLandCarbonSink,
-                          mbind(
-                            emissionsReport,
-                            setNames(grassiLandCarbonSink,       "Emissions|CO2|Land Carbon Sink|Cumulative|Grassi (Gt CO2)"),
-                            setNames(LPJmlLandCarbonSink,        "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL (Gt CO2)"),
-                            setNames(managedLand,                "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|+|Managed Land (Gt CO2)"),
-                            setNames(managedAg,                  "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|+|Agricultural Land (Gt CO2)"),
-                            setNames(managedAgCrop,              "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Agricultural land|+|Cropland (Gt CO2)"),
-                            setNames(managedAgPast,              "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Agricultural land|+|Pasture (Gt CO2)"),
-                            setNames(managedForest,              "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|+|Managed Forest (Gt CO2)"),
-                            setNames(managedForestSecdForest,    "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Managed Forest|+|Secondary Forest (Gt CO2)"),
-                            setNames(managedForestForestryAff,   "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Managed Forest|+|CO2-price AR (Gt CO2)"),
-                            setNames(managedForestForestryNDC,   "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Managed Forest|+|NPI_NDC AR (Gt CO2)"),
-                            setNames(managedForestForestryPlant, "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Managed Forest|+|Timber Plantations (Gt CO2)"),
-                            setNames(managedUrban,               "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|+|Urban Land (Gt CO2)"),
-                            setNames(unmanagedLand,              "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|+|Unmanaged Land (Gt CO2)"),
-                            setNames(unmanagedLandPrimForest,    "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Unmanaged Land|+|Primary Forest (Gt CO2)"),
-                            setNames(unmanagedLandOther,         "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Unmanaged Land|+|Other Land (Gt CO2)")
-                          )
-  )
+  emissionsReport <- with(cumulativeLandCarbonSink, mbind(
+    emissionsReport,
+    
+    setNames(grassiLandCarbonSink,       "Emissions|CO2|Land Carbon Sink|Cumulative|Grassi (Gt CO2)"),
+    setNames(LPJmlLandCarbonSink,        "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL (Gt CO2)"),
+    setNames(managedLand,                "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|+|Managed Land (Gt CO2)"),
+    setNames(managedAg,                  "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|+|Agricultural Land (Gt CO2)"),
+    setNames(managedAgCrop,              "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Agricultural land|+|Cropland (Gt CO2)"),
+    setNames(managedAgPast,              "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Agricultural land|+|Pasture (Gt CO2)"),
+    setNames(managedForest,              "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|+|Managed Forest (Gt CO2)"),
+    setNames(managedForestSecdForest,    "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Managed Forest|+|Secondary Forest (Gt CO2)"),
+    setNames(managedForestForestryAff,   "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Managed Forest|+|CO2-price AR (Gt CO2)"),
+    setNames(managedForestForestryNDC,   "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Managed Forest|+|NPI_NDC AR (Gt CO2)"),
+    setNames(managedForestForestryPlant, "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|Managed Forest|+|Timber Plantations (Gt CO2)"),
+    setNames(managedUrban,               "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Managed Land|+|Urban Land (Gt CO2)"),
+    setNames(unmanagedLand,              "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|+|Unmanaged Land (Gt CO2)"),
+    setNames(unmanagedLandPrimForest,    "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Unmanaged Land|+|Primary Forest (Gt CO2)"),
+    setNames(unmanagedLandOther,         "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Unmanaged Land|+|Other Land (Gt CO2)")
+  ))
   # nolint end
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # N2O, NOx, NH3 emissions reporting
-
+  
   .generateNitrogenReport <- function(.type) {
-
+    
     .createReport <- function(.emission, .source, .name = NULL) {
       type <- getItems(.emission, dim = 3.2)
-
+      
       unit <- type
       if (unit %in% c("n2o_direct", "n2o_indirect")) {
         unit <- "n2o"
       }
       unit <- reportingnames(unit)
-
+      
       t <- dimSums(.emission[, , .source], dim = 3)
       n <- paste0("Emissions|", reportingnames(type), "|Land", .name, " (Mt ", unit, "/yr)")
       return(setNames(t, n))
     }
-
-
+    
     agriculture <- c("SOM", "inorg_fert", "man_crop", "awms", "resid", "man_past", "rice")
     burn <- c("resid_burn")
     peatland_n2o <- c("peatland")
-
+    
     nEmissions <- Emissions(gdx, level = "regglo", type = .type, unit = "gas", subcategories = TRUE, inorg_fert_split = TRUE)
     # use PeatlandEmissions for reporting to exclude emissions from intact peatlands
     if (.type %in% c("n2o_n", "n2o_n_direct")) {
@@ -475,8 +490,7 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
         nEmissions[, , "peatland"] <- collapseNames(peatlandN2O[, , "n2o"])
       }
     }
-
-
+    
     # nolint start
     .x <- mbind(
       .createReport(nEmissions, c(agriculture, burn, peatland_n2o)),
@@ -495,34 +509,32 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       .createReport(nEmissions, c("resid_burn"),                                                 "|Biomass Burning|+|Burning of Crop Residues")
     )
     # nolint end
-
+    
     # Old versions of MAgPIE may not include peatlands
     if ("peatland" %in% getItems(nEmissions, dim = 3.1)) {
-
       .x <- mbind(
         .x,
         .createReport(nEmissions, peatland_n2o,  "|+|Peatland"),
         .createReport(nEmissions, c("peatland"), "|Peatland|+|Managed")
       )
-
     }
-
+    
     return(.x)
-
+    
   }
-
+  
   nEmisTypes <- c("n2o_n", "nh3_n", "no2_n", "no3_n", "n2o_n_direct", "n2o_n_indirect")
   nitrogenEmissions <- mbind(lapply(X = nEmisTypes, FUN = .generateNitrogenReport))
   emissionsReport <- mbind(emissionsReport, nitrogenEmissions)
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # CH4 emissions reporting
-
+  
   agricult_ch4 <- c("rice", "awms", "ent_ferm")
   burn_ch4 <- c("resid_burn")
   peatland_ch4 <- "peatland"
-
+  
   # combine all CH4 emissions in one object
   ch4 <- collapseNames(Emissions(gdx, level = "regglo", type = "ch4", unit = "gas", subcategories = TRUE), collapsedim = 2)
   # use PeatlandEmissions for reporting to exclude emissions from intact peatlands
@@ -534,7 +546,7 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     peatlandCH4 <- setNames(collapseNames(peatlandCH4[, , "ch4"]), "peatland")
     ch4 <- mbind(ch4, peatlandCH4)
   }
-
+  
   # nolint start
   emissionsReport <- mbind(
     emissionsReport,
@@ -549,18 +561,18 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     setNames(dimSums(ch4[, , c("peatland")], dim = 3),                           "Emissions|CH4|Land|Peatland|+|Managed (Mt CH4/yr)")
   )
   # nolint end
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # N2O GWP100AR6 emissions reporting
-
+  
   .generateGWPN2O <- function(.unit) {
-
+    
     agriculture <- c("SOM", "inorg_fert", "man_crop", "awms", "resid", "man_past", "rice")
-
+    
     emissions <- Emissions(gdx, level = "regglo", type = "n2o_n", unit = .unit, subcategories = TRUE)
     emissions <- collapseNames(emissions, collapsedim = 2)
-
+    
     # disaggregate N2O emissions to croparea by crop using Nitrogen withdrawals as weight
     withdrawalN  <- collapseNames(NitrogenBudgetWithdrawals(gdx, kcr = "kcr", net = TRUE, level = "regglo"))
     emisCroparea <- dimSums(emissions[, , c("SOM", "inorg_fert", "man_crop", "awms", "resid", "rice")], dim = 3)
@@ -573,13 +585,13 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
                                        level_zero_name = "Emissions|N2O_GWP100AR6|Land|Agriculture|Croparea",
                                        detail = TRUE, sort = FALSE, partly = FALSE, version = NULL)
     getItems(emisCropareabycrop, dim = 3) <- paste0(getItems(emisCropareabycrop, dim = 3), " (Mt CO2e/yr)")
-
+    
     .createReport <- function(.emission, .name = NULL) {
       t <- dimSums(emissions[, , .emission], dim = 3)
       n <- paste0("Emissions|N2O_", .unit, "|Land", .name, " (Mt CO2e/yr)")
       return(setNames(t, n))
     }
-
+    
     # nolint start
     .x <- mbind(
       .createReport(c(agriculture, "resid_burn", "peatland")),
@@ -600,30 +612,30 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       emisCropareabycrop
     )
     # nolint end
-
+    
     return(.x)
   }
-
+  
   emissionsReport <- mbind(
     emissionsReport,
     .generateGWPN2O("GWP100AR6")
   )
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # CH4 GWP100AR6 and GWP*AR6 emissions reporting
-
+  
   .generateGWPCH4 <- function(.unit) {
-
+    
     emissions <- Emissions(gdx, level = "regglo", type = "ch4", unit = .unit, subcategories = TRUE)
     emissions <- collapseNames(emissions, collapsedim = 2)
-
+    
     .createReport <- function(.emission, .name = NULL) {
       t <- dimSums(emissions[, , .emission], dim = 3)
       n <- paste0("Emissions|CH4_", .unit, "|Land", .name, " (Mt CO2e/yr)")
       return(setNames(t, n))
     }
-
+    
     # nolint start
     .x <- mbind(
       .createReport(c("rice", "awms", "ent_ferm", "resid_burn", "peatland")),
@@ -637,78 +649,78 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       .createReport(c("peatland"),                                            "|Peatland|+|Managed")
     )
     # nolint end
-
+    
     return(.x)
   }
-
+  
   emissionsReport <- mbind(
     emissionsReport,
     .generateGWPCH4("GWP100AR6"),
     .generateGWPCH4("GWP*AR6")
   )
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # Total yearly CO2e (for GWP100AR6) emissions reporting
-
+  
   .generateTotalGWP <- function(.unit) {
     reports <- c(paste0("Emissions|CH4_", .unit, "|Land (Mt CO2e/yr)"),
                  paste0("Emissions|N2O_", .unit, "|Land (Mt CO2e/yr)"),
                  "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)")
-
+    
     total <- dimSums(emissionsReport[, , reports], dim = 3) * 0.001 # Mt to Gt CO2e
     total <- setNames(total, paste0("Emissions|", .unit, "|Land (Gt CO2e/yr)"))
-
+    
     return(total)
   }
-
+  
   emissionsReport <- mbind(
     emissionsReport,
     .generateTotalGWP("GWP100AR6")
   )
-
-
+  
+  
   # -----------------------------------------------------------------------------------------------------------------
   # Total cumulative CO2e (for GWP100AR6) emissions reporting
-
+  
   .generateCumulativeGWP <- function(.unit) {
-
+    
     years <- getYears(emissionsReport, as.integer = TRUE)
-
+    
     # accumulate flow reports (CH4, N2O)
     flows <- emissionsReport[, , c(paste0("Emissions|CH4_", .unit, "|Land (Mt CO2e/yr)"),
                                    paste0("Emissions|N2O_", .unit, "|Land (Mt CO2e/yr)"))]
     flows <- flows[, years, ]
     flows[, c("y1995", "y2000"), ] <- 0
-
+    
     flows <- time_interpolate(flows, interpolated_year = min(years):max(years))
     flows <- as.magpie(apply(flows, c(1, 3), cumsum))
     flows <- flows[, years, ]
-
+    
     # accumulate stock reports (CO2)
     stock <- emissionsReport[, , "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)"]
     stock <- stock[, years, ]
     stock[, c("y1995", "y2000"), ] <- 0
-
+    
     im_years <- m_yeardiff(gdx)[, years, ]
     stock <- stock * im_years
     stock <- as.magpie(apply(stock, c(1, 3), cumsum))
-
+    
     # combine accounting of stocks and flows
     all <- setNames(stock, NULL) + dimSums(flows, dim = 3)
     all <- all * 0.001  # Mt to Gt CO2e
     all <- setNames(all, paste0("Emissions|", .unit, "|Land|Cumulative (Gt CO2e)"))
-
+    
     all[, "y1995", ] <- NA
-
+    
     return(all)
   }
-
+  
   emissionsReport <- mbind(
     emissionsReport,
     .generateCumulativeGWP("GWP100AR6")
   )
-
+  
   return(emissionsReport)
-
+  
 }

--- a/R/reportEmissions.R
+++ b/R/reportEmissions.R
@@ -82,7 +82,7 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     other_conversion <- collapseNames(dimSums(co2[, , "lu_other_conversion"], dim = "c_pools"))
     regrowth         <- collapseNames(dimSums(co2[, , "lu_regrowth"],         dim = "c_pools"))
 
-    # TODO How does the LTS change the pools here?
+    # The LTS pools will also need to be recaculated with wood products
     # Above Ground / Below Ground Carbon
     totalPools   <- collapseNames(dimSums(co2[, , "total"], dim = "land"))
     climatePools <- collapseNames(dimSums(co2[, , "cc"],    dim = "land"))

--- a/R/reportEmissions.R
+++ b/R/reportEmissions.R
@@ -30,25 +30,25 @@
 #' @md
 #'
 reportEmissions <- function(gdx, storageWood = TRUE) {
-  
+
   # -----------------------------------------------------------------------------------------------------------------
   # Calculate CO2 emissions from a MAgPIE .gdx file
-  
+
   # landuseChange is mostly positive (deforestation) and regrowth is mostly negative (regrowth/afforestation),
   #   but there are some cases that behave differently.
-  
+
   # landuseChange: cropland-to-pasture conversion causes negative emissions in soilc
-  
+
   # regrowth: Litter carbon can decrease in case of afforestation/regrowth because the starting
   #   level of litter carbon is always pasture litc. If pasture litc is higher than natveg
   #   litc, this results in positive emissions.
-  
+
   .calcCO2 <- function(.lowpass = 3, .cumulative = FALSE, .raw = FALSE, .landCarbonSink = "grassi") {
-    
+
     co2 <- emisCO2(gdx,
                    level = "regglo", unit = "gas", sum_land = FALSE, sum_cpool = FALSE,
                    lowpass = .lowpass, cumulative = .cumulative)
-    
+
     if (.landCarbonSink == "grassi") {
       # To ensure consistency with national forest inventories, we replace our estimates of indirect emissions
       # from climate change (on all MAgPIE land-use types) with the emission land-carbon sink of
@@ -57,80 +57,80 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     } else {
       eClimateChange <- dimSums(co2[, , "cc"], dim = 3)
     }
-    
+
     # If cumulative, convert Mt CO2 to Gt CO2
     if (.cumulative) {
       co2 <- co2 / 1000
       eClimateChange <- eClimateChange / 1000
     }
-    
+
     eLanduseChange <- dimSums(co2[, , "lu"], dim = 3)
     totalNetFlux   <- eLanduseChange + eClimateChange
-    
+
     if (.raw) {
       .x = list(
         totalNetFlux   = totalNetFlux,
         eLanduseChange = eLanduseChange,
         eClimateChange = eClimateChange)
-      
+
       return(.x)
     }
-    
+
     # Emission from deforestation, degradation, and other land conversion
     deforestation    <- collapseNames(dimSums(co2[, , "lu_deforestation"],    dim = "c_pools"))
     degradation      <- collapseNames(dimSums(co2[, , "lu_degrad"],           dim = "c_pools"))
     other_conversion <- collapseNames(dimSums(co2[, , "lu_other_conversion"], dim = "c_pools"))
     regrowth         <- collapseNames(dimSums(co2[, , "lu_regrowth"],         dim = "c_pools"))
-    
-    # TODO How does the LTS change the pools here? 
+
+    # TODO How does the LTS change the pools here?
     # Above Ground / Below Ground Carbon
     totalPools   <- collapseNames(dimSums(co2[, , "total"], dim = "land"))
     climatePools <- collapseNames(dimSums(co2[, , "cc"],    dim = "land"))
     landusePools <- collapseNames(dimSums(co2[, , "lu"],    dim = "land"))
-    
+
     # Calculate wood products, if forestry module was activated and desired
     emisWoodProducts <- carbonLTS(gdx, level = "regglo", unit = "gas", cumulative = .cumulative)[, getYears(totalNetFlux), ]
-    
+
     if (!is.null(emisWoodProducts) && storageWood) {
-      
+
       if (.cumulative) {
         # Can't divide by 1000 during cumulative calc as in def runs its NULL and NULL/1000 is numeric(0)
         emisWoodProducts <- emisWoodProducts / 1000
       }
-      
+
       # All categories
       inflow  <- collapseNames(emisWoodProducts[, , "annual_inflow"])
       outflow <- collapseNames(emisWoodProducts[, , "annual_outflow"])
-      
+
       # Wood products (not including constr wood)
       emisWood        <- collapseNames(emisWoodProducts[, , "emis_wood"])        # -1 removed in carbonLTS_IPCC.R
       emisWoodFuel    <- collapseNames(emisWoodProducts[, , "emis_woodfuel"])    # -1 removed in carbonLTS_IPCC.R
       emisConstrWood  <- collapseNames(emisWoodProducts[, , "emis_constr_wood"]) # -1 removed in carbonLTS_IPCC.R
-      
+
       # Purely industrial roundwood
       emisWoodInflow  <- collapseNames(emisWoodProducts[, , "wood_inflow"]) # inflow is negative emissions
       emisWoodOutflow <- collapseNames(emisWoodProducts[, , "wood_outflow"])
-      emisWoodNet     <- collapseNames(emisWoodInflow + emisWoodOutflow) 
-      
+      emisWoodNet     <- collapseNames(emisWoodInflow + emisWoodOutflow)
+
       # Building materials
       emisBuildingInflow  <- collapseNames(emisWoodProducts[, , "building_inflow"]) # inflow is negative emissions
       emisBuildingOutflow <- collapseNames(emisWoodProducts[, , "building_outflow"])
-      emisBuildingNet     <- collapseNames(emisBuildingInflow + emisBuildingOutflow) 
-      
+      emisBuildingNet     <- collapseNames(emisBuildingInflow + emisBuildingOutflow)
+
       # Sum of net emissions from industrial roundwood and building material
       storage <- emisWoodNet + emisBuildingNet
-      
+
       # Total emissions from wood harvest
       wood <- emisWoodFuel + storage # emisWood is already accounted for in storage
-      
+
       # remove negative emissions from long-term storage of wood products
       harvestOld <- dimSums(co2[, , "lu_harvest"], dim = 3)
-      harvestNew <- harvestOld - (emisWoodInflow + emisBuildingInflow)
+      harvestNew <- harvestOld + (emisWoodInflow + emisBuildingInflow)
       eLanduseChange <- eLanduseChange - harvestOld + harvestNew
       totalNetFlux   <- eLanduseChange + eClimateChange
-      
+
     } else {
-      
+
       wood                <- NULL
       emisWoodFuel        <- NULL
       storage             <- NULL
@@ -142,9 +142,9 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       emisBuildingNet     <- NULL
       emisBuildingInflow  <- NULL
       emisBuildingOutflow <- NULL
-      
+
     }
-    
+
     # use PeatlandEmissions for reporting to exclude emissions from intact peatlands
     # No lowpass filter applied to peatland emissions
     peatland <- PeatlandEmissions(gdx, cumulative = .cumulative, unit = "gas", level = "regglo", intact = FALSE)
@@ -153,14 +153,14 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     } else {
       peatland <- setNames(dimSums(peatland[, , c("co2", "doc")], dim = 3), "peatland")
     }
-    
+
     if (.cumulative) {
       peatland <- peatland / 1000
     }
-    
+
     totalNetFlux   <- totalNetFlux + peatland
     eLanduseChange <- eLanduseChange + peatland
-    
+
     # generate return list
     .x <- list(
       totalNetFlux               = totalNetFlux,
@@ -186,42 +186,42 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       climatePools               = climatePools,
       landusePools               = landusePools
     )
-    
+
     return(.x)
   }
-  
+
   # -----------------------------------------------------------------------------------------------------------------
   # Generate reports
-  
+
   emissionsReport <- NULL
-  
+
   # -----------------------------------------------------------------------------------------------------------------
   # Yearly CO2 emissions, lowpass = 3
-  
+
   yearlyCO2 <- .calcCO2(.lowpass = 3, .cumulative = FALSE)
-  
+
   # nolint start
   emissionsReport <- with(yearlyCO2, mbind(
-    emissionsReport, 
-    
+    emissionsReport,
+
     setNames(totalNetFlux,                        "Emissions|CO2|Land (Mt CO2/yr)"), # all human-induced land-related CO2 emissions
     setNames(eClimateChange,                      "Emissions|CO2|Land|+|Indirect (Mt CO2/yr)"), # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
     setNames(eLanduseChange,                      "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
-    
+
     # Gross emissions - Deforestation
     setNames(dimSums(deforestation, dim = 3),     "Emissions|CO2|Land|Land-use Change|+|Deforestation (Mt CO2/yr)"),
     setNames(deforestation[, , "primforest"],     "Emissions|CO2|Land|Land-use Change|Deforestation|+|Primary forests (Mt CO2/yr)"),
     setNames(deforestation[, , "secdforest"],     "Emissions|CO2|Land|Land-use Change|Deforestation|+|Secondary forests (Mt CO2/yr)"),
     setNames(deforestation[, , "forestry_plant"], "Emissions|CO2|Land|Land-use Change|Deforestation|+|Forestry plantations (Mt CO2/yr)"),
-    
+
     # Gross emissions - Degradataion
     setNames(dimSums(degradation, dim = 3),       "Emissions|CO2|Land|Land-use Change|+|Forest degradation (Mt CO2/yr)"),
     setNames(degradation[, , "primforest"],       "Emissions|CO2|Land|Land-use Change|Forest degradation|+|Primary forests (Mt CO2/yr)"),
     setNames(degradation[, , "secdforest"],       "Emissions|CO2|Land|Land-use Change|Forest degradation|+|Secondary forests (Mt CO2/yr)"),
-    
+
     # Gross emissions - Other conversion
     setNames(other_conversion[, , "other"],       "Emissions|CO2|Land|Land-use Change|+|Other land conversion (Mt CO2/yr)"),
-    
+
     # Regrowth
     setNames(dimSums(regrowth, dim = 3),          "Emissions|CO2|Land|Land-use Change|+|Regrowth (Mt CO2/yr)"),
     setNames(regrowth[, , "forestry_aff"],        "Emissions|CO2|Land|Land-use Change|Regrowth|+|CO2-price AR (Mt CO2/yr)"),
@@ -229,23 +229,23 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     setNames(regrowth[, , "forestry_plant"],      "Emissions|CO2|Land|Land-use Change|Regrowth|+|Timber Plantations (Mt CO2/yr)"),
     setNames(regrowth[, , "secdforest"],          "Emissions|CO2|Land|Land-use Change|Regrowth|+|Secondary Forest (Mt CO2/yr)"),
     setNames(regrowth[, , "other"],               "Emissions|CO2|Land|Land-use Change|Regrowth|+|Other Land (Mt CO2/yr)"),
-    
+
     # Gross emissions - Peatland
     setNames(peatland,                            "Emissions|CO2|Land|Land-use Change|+|Peatland (Mt CO2/yr)"),
-    
+
     # Carbon pools
     setNames(totalPools,                           paste0("Emissions|CO2|Land|++|", getNames(totalPools), " (Mt CO2/yr)")),
     setNames(climatePools,                         paste0("Emissions|CO2|Land|Indirect|++|", getNames(climatePools), " (Mt CO2/yr)")),
     setNames(landusePools,                         paste0("Emissions|CO2|Land|Land-use Change|++|", getNames(landusePools), " (Mt CO2/yr)"))
-    
+
   ))
-  
+
   # Only attempt to append wood-related reports if the forestry module was activated
   if (!is.null(yearlyCO2$wood)) {
-    
+
     emissionsReport <- with(yearlyCO2, mbind(
       emissionsReport,
-      
+
       setNames(emisWoodFuel,        "Emissions|CO2|Land|Land-use Change|Wood Harvest|++|Short Lived Products (Mt CO2/yr)"),
       setNames(storage,             "Emissions|CO2|Land|Land-use Change|Wood Harvest|++|Storage (Mt CO2/yr)"), # carbon stored in wood products + release from wood products
       # setNames(inflow,            "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Inflow (Mt CO2/yr)"), # carbon stored in wood products
@@ -257,53 +257,53 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       setNames(emisBuildingInflow,  "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Mt CO2/yr)"), # carbon stored in wood buildings
       setNames(emisBuildingOutflow, "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Mt CO2/yr)") # slow release from wood buildings
     ))
-    
+
   }
   # nolint end
-  
+
   # -----------------------------------------------------------------------------------------------------------------
   # RAW yearly CO2 emissions, lowpass = 0
-  
+
   rawYearlyCO2 <- .calcCO2(.lowpass = 0, .cumulative = FALSE, .raw = TRUE)
-  
+
   # nolint start
   emissionsReport <- with(rawYearlyCO2, mbind(
     emissionsReport,
-    
+
     setNames(totalNetFlux,   "Emissions|CO2|Land RAW (Mt CO2/yr)"),
     setNames(eLanduseChange, "Emissions|CO2|Land RAW|+|Land-use Change RAW (Mt CO2/yr)"),
     setNames(eClimateChange, "Emissions|CO2|Land RAW|+|Indirect RAW (Mt CO2/yr)")
   ))
   # nolint end
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # Cumulative CO2 emissions, lowpass = 3
-  
+
   cumulativeCO2 <- .calcCO2(.lowpass = 3, .cumulative = TRUE)
-  
+
   # nolint start
   emissionsReport <- with(cumulativeCO2, mbind(
     emissionsReport,
-    
+
     setNames(totalNetFlux,                        "Emissions|CO2|Land|Cumulative (Gt CO2)"), # all human-induced land-related CO2 emissions
     setNames(eClimateChange,                      "Emissions|CO2|Land|Cumulative|+|Indirect (Gt CO2)"), # indirect human-induced CO2 emissions: environmental change, climate change, natural effects
     setNames(eLanduseChange,                      "Emissions|CO2|Land|Cumulative|+|Land-use Change (Gt CO2)"), # direct human-induced CO2 emissions, includes land-use change, land management and regrowth of vegetation
-    
+
     # Gross emissions - Deforestation
     setNames(dimSums(deforestation, dim = 3),     "Emissions|CO2|Land|Cumulative|Land-use Change|+|Deforestation (Gt CO2)"),
     setNames(deforestation[, , "primforest"],     "Emissions|CO2|Land|Cumulative|Land-use Change|Deforestation|+|Primary forests (Gt CO2)"),
     setNames(deforestation[, , "secdforest"],     "Emissions|CO2|Land|Cumulative|Land-use Change|Deforestation|+|Secondary forests (Gt CO2)"),
     setNames(deforestation[, , "forestry_plant"], "Emissions|CO2|Land|Cumulative|Land-use Change|Deforestation|+|Forestry plantations (Gt CO2)"),
-    
+
     # Gross emissions - Degradataion
     setNames(dimSums(degradation, dim = 3),       "Emissions|CO2|Land|Cumulative|Land-use Change|+|Forest degradation (Gt CO2)"),
     setNames(degradation[, , "primforest"],       "Emissions|CO2|Land|Cumulative|Land-use Change|Forest degradation|+|Primary forests (Gt CO2)"),
     setNames(degradation[, , "secdforest"],       "Emissions|CO2|Land|Cumulative|Land-use Change|Forest degradation|+|Secondary forests (Gt CO2)"),
-    
+
     # Gross emissions - Other conversion
     setNames(other_conversion[, , "other"],       "Emissions|CO2|Land|Cumulative|Land-use Change|+|Other land conversion (Gt CO2)"),
-    
+
     # Regrowth
     setNames(dimSums(regrowth, dim = 3),          "Emissions|CO2|Land|Cumulative|Land-use Change|+|Regrowth (Gt CO2)"),
     setNames(regrowth[, , "forestry_aff"],        "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|+|CO2-price AR (Gt CO2)"),
@@ -311,23 +311,23 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     setNames(regrowth[, , "forestry_plant"],      "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|+|Timber Plantations (Gt CO2)"),
     setNames(regrowth[, , "secdforest"],          "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|+|Secondary Forest (Gt CO2)"),
     setNames(regrowth[, , "other"],               "Emissions|CO2|Land|Cumulative|Land-use Change|Regrowth|+|Other Land (Gt CO2)"),
-    
+
     # Gross emissions - Peatland
     setNames(peatland,                            "Emissions|CO2|Land|Cumulative|Land-use Change|+|Peatland (Gt CO2)"),
-    
+
     # Carbon pools
     setNames(totalPools,                          paste0("Emissions|CO2|Land|Cumulative|++|", getNames(totalPools), " (Gt CO2)")),
     setNames(climatePools,                        paste0("Emissions|CO2|Land|Cumulative|Indirect|++|", getNames(climatePools), " (Gt CO2)")),
     setNames(landusePools,                        paste0("Emissions|CO2|Land|Cumulative|Land-use Change|++|", getNames(landusePools), " (Gt CO2)"))
-    
+
   ))
-  
+
   # Only attempt to append wood-related reports if the forestry module was activated
   if (!is.null(cumulativeCO2$wood)) {
-    
+
     emissionsReport <- with(cumulativeCO2, mbind(
       emissionsReport,
-      
+
       setNames(emisWoodFuel,        "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|++|Short Lived Products (Gt CO2)"),
       setNames(storage,             "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|++|Storage (Gt CO2)"), # carbon stored in wood products + release from wood products
       # setNames(inflow,            "Emissions|CO2|Land|Land-use Change|Wood Harvest|Storage|+|Inflow (Mt CO2/yr)"), # carbon stored in wood products
@@ -339,45 +339,45 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       setNames(emisBuildingInflow,  "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Inflow (Gt CO2)"), # carbon stored in wood buildings
       setNames(emisBuildingOutflow, "Emissions|CO2|Land|Cumulative|Land-use Change|Wood Harvest|Storage|Buildings|Outflow (Gt CO2)") # slow release from wood buildings
     ))
-    
+
   }
   # nolint end
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # Calculated indirect emissions from land-use change from a .gdx file
-  
+
   .calcLandCarbonSink <- function(.lowpass = 3, .cumulative = FALSE) {
-    
+
     # Estimate of land-carbon sink from LPJmL
     co2 <- emisCO2(gdx,
                    level = "regglo", unit = "gas", sum_land = FALSE, sum_cpool = FALSE,
                    lowpass = .lowpass, cumulative = .cumulative)
-    
+
     # Estimate of land-carbon sink from LPJmL
     LPJmlLCS <- co2[, , "cc", drop = TRUE]
     LPJmlLCS <- dimSums(LPJmlLCS, dim = 3.2) # Sum above- and belowground carbon
-    
+
     # Estimate of land-carbon sink from Grassi et al. (2021)
     grassiLandCarbonSink <- landCarbonSink(gdx, level = "regglo", cumulative = .cumulative)
-    
+
     # If cumulative, convert Mt CO2 to Gt CO2
     if (.cumulative) {
       LPJmlLCS  <- LPJmlLCS / 1000
       grassiLandCarbonSink <- grassiLandCarbonSink / 1000
     }
-    
+
     # Managed land summation groupings
     managedAg     <- c("crop", "past")
     managedForest <- c("secdforest", "forestry_aff", "forestry_ndc", "forestry_plant")
     managedLand   <- c(managedAg, managedForest, "urban")
-    
+
     # Unmanaged land summation groupings
     unmanagedLand <- c("primforest", "other")
-    
+
     # Total includes urban land
     totalLandCarbonSink <- c(managedLand, unmanagedLand)
-    
+
     .x <- list(grassiLandCarbonSink       = grassiLandCarbonSink,
                LPJmlLandCarbonSink        = dimSums(LPJmlLCS[, , totalLandCarbonSink], dim = 3),
                managedLand                = dimSums(LPJmlLCS[, , managedLand], dim = 3),
@@ -394,20 +394,20 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
                unmanagedLandPrimForest    = LPJmlLCS[, , "primforest", drop = TRUE],
                unmanagedLandOther         = LPJmlLCS[, , "other", drop = TRUE]
     )
-    
+
     return(.x)
   }
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # Yearly indirect CO2 emissions from land-use change (land-carbon sink) reporting
-  
+
   landCarbonSink <- .calcLandCarbonSink()
-  
+
   # nolint start
   emissionsReport <- with(landCarbonSink, mbind(
     emissionsReport,
-    
+
     setNames(grassiLandCarbonSink,       "Emissions|CO2|Land Carbon Sink|Grassi|Managed Land|Managed Forest (Mt CO2/yr)"),
     setNames(LPJmlLandCarbonSink,        "Emissions|CO2|Land Carbon Sink|LPJmL (Mt CO2/yr)"),
     setNames(managedLand,                "Emissions|CO2|Land Carbon Sink|LPJmL|+|Managed Land (Mt CO2/yr)"),
@@ -425,17 +425,17 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     setNames(unmanagedLandOther,         "Emissions|CO2|Land Carbon Sink|LPJmL|Unmanaged Land|+|Other Land (Mt CO2/yr)")
   ))
   # nolint end
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # Cumulative indirect CO2 emissions from land-use change (land-carbon sink) reporting
-  
+
   cumulativeLandCarbonSink <- .calcLandCarbonSink(.cumulative = TRUE)
-  
+
   # nolint start
   emissionsReport <- with(cumulativeLandCarbonSink, mbind(
     emissionsReport,
-    
+
     setNames(grassiLandCarbonSink,       "Emissions|CO2|Land Carbon Sink|Cumulative|Grassi (Gt CO2)"),
     setNames(LPJmlLandCarbonSink,        "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL (Gt CO2)"),
     setNames(managedLand,                "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|+|Managed Land (Gt CO2)"),
@@ -453,31 +453,31 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     setNames(unmanagedLandOther,         "Emissions|CO2|Land Carbon Sink|Cumulative|LPJmL|Unmanaged Land|+|Other Land (Gt CO2)")
   ))
   # nolint end
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # N2O, NOx, NH3 emissions reporting
-  
+
   .generateNitrogenReport <- function(.type) {
-    
+
     .createReport <- function(.emission, .source, .name = NULL) {
       type <- getItems(.emission, dim = 3.2)
-      
+
       unit <- type
       if (unit %in% c("n2o_direct", "n2o_indirect")) {
         unit <- "n2o"
       }
       unit <- reportingnames(unit)
-      
+
       t <- dimSums(.emission[, , .source], dim = 3)
       n <- paste0("Emissions|", reportingnames(type), "|Land", .name, " (Mt ", unit, "/yr)")
       return(setNames(t, n))
     }
-    
+
     agriculture <- c("SOM", "inorg_fert", "man_crop", "awms", "resid", "man_past", "rice")
     burn <- c("resid_burn")
     peatland_n2o <- c("peatland")
-    
+
     nEmissions <- Emissions(gdx, level = "regglo", type = .type, unit = "gas", subcategories = TRUE, inorg_fert_split = TRUE)
     # use PeatlandEmissions for reporting to exclude emissions from intact peatlands
     if (.type %in% c("n2o_n", "n2o_n_direct")) {
@@ -490,7 +490,7 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
         nEmissions[, , "peatland"] <- collapseNames(peatlandN2O[, , "n2o"])
       }
     }
-    
+
     # nolint start
     .x <- mbind(
       .createReport(nEmissions, c(agriculture, burn, peatland_n2o)),
@@ -509,7 +509,7 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       .createReport(nEmissions, c("resid_burn"),                                                 "|Biomass Burning|+|Burning of Crop Residues")
     )
     # nolint end
-    
+
     # Old versions of MAgPIE may not include peatlands
     if ("peatland" %in% getItems(nEmissions, dim = 3.1)) {
       .x <- mbind(
@@ -518,23 +518,23 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
         .createReport(nEmissions, c("peatland"), "|Peatland|+|Managed")
       )
     }
-    
+
     return(.x)
-    
+
   }
-  
+
   nEmisTypes <- c("n2o_n", "nh3_n", "no2_n", "no3_n", "n2o_n_direct", "n2o_n_indirect")
   nitrogenEmissions <- mbind(lapply(X = nEmisTypes, FUN = .generateNitrogenReport))
   emissionsReport <- mbind(emissionsReport, nitrogenEmissions)
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # CH4 emissions reporting
-  
+
   agricult_ch4 <- c("rice", "awms", "ent_ferm")
   burn_ch4 <- c("resid_burn")
   peatland_ch4 <- "peatland"
-  
+
   # combine all CH4 emissions in one object
   ch4 <- collapseNames(Emissions(gdx, level = "regglo", type = "ch4", unit = "gas", subcategories = TRUE), collapsedim = 2)
   # use PeatlandEmissions for reporting to exclude emissions from intact peatlands
@@ -546,7 +546,7 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     peatlandCH4 <- setNames(collapseNames(peatlandCH4[, , "ch4"]), "peatland")
     ch4 <- mbind(ch4, peatlandCH4)
   }
-  
+
   # nolint start
   emissionsReport <- mbind(
     emissionsReport,
@@ -561,18 +561,18 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
     setNames(dimSums(ch4[, , c("peatland")], dim = 3),                           "Emissions|CH4|Land|Peatland|+|Managed (Mt CH4/yr)")
   )
   # nolint end
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # N2O GWP100AR6 emissions reporting
-  
+
   .generateGWPN2O <- function(.unit) {
-    
+
     agriculture <- c("SOM", "inorg_fert", "man_crop", "awms", "resid", "man_past", "rice")
-    
+
     emissions <- Emissions(gdx, level = "regglo", type = "n2o_n", unit = .unit, subcategories = TRUE)
     emissions <- collapseNames(emissions, collapsedim = 2)
-    
+
     # disaggregate N2O emissions to croparea by crop using Nitrogen withdrawals as weight
     withdrawalN  <- collapseNames(NitrogenBudgetWithdrawals(gdx, kcr = "kcr", net = TRUE, level = "regglo"))
     emisCroparea <- dimSums(emissions[, , c("SOM", "inorg_fert", "man_crop", "awms", "resid", "rice")], dim = 3)
@@ -585,13 +585,13 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
                                        level_zero_name = "Emissions|N2O_GWP100AR6|Land|Agriculture|Croparea",
                                        detail = TRUE, sort = FALSE, partly = FALSE, version = NULL)
     getItems(emisCropareabycrop, dim = 3) <- paste0(getItems(emisCropareabycrop, dim = 3), " (Mt CO2e/yr)")
-    
+
     .createReport <- function(.emission, .name = NULL) {
       t <- dimSums(emissions[, , .emission], dim = 3)
       n <- paste0("Emissions|N2O_", .unit, "|Land", .name, " (Mt CO2e/yr)")
       return(setNames(t, n))
     }
-    
+
     # nolint start
     .x <- mbind(
       .createReport(c(agriculture, "resid_burn", "peatland")),
@@ -612,30 +612,30 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       emisCropareabycrop
     )
     # nolint end
-    
+
     return(.x)
   }
-  
+
   emissionsReport <- mbind(
     emissionsReport,
     .generateGWPN2O("GWP100AR6")
   )
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # CH4 GWP100AR6 and GWP*AR6 emissions reporting
-  
+
   .generateGWPCH4 <- function(.unit) {
-    
+
     emissions <- Emissions(gdx, level = "regglo", type = "ch4", unit = .unit, subcategories = TRUE)
     emissions <- collapseNames(emissions, collapsedim = 2)
-    
+
     .createReport <- function(.emission, .name = NULL) {
       t <- dimSums(emissions[, , .emission], dim = 3)
       n <- paste0("Emissions|CH4_", .unit, "|Land", .name, " (Mt CO2e/yr)")
       return(setNames(t, n))
     }
-    
+
     # nolint start
     .x <- mbind(
       .createReport(c("rice", "awms", "ent_ferm", "resid_burn", "peatland")),
@@ -649,78 +649,78 @@ reportEmissions <- function(gdx, storageWood = TRUE) {
       .createReport(c("peatland"),                                            "|Peatland|+|Managed")
     )
     # nolint end
-    
+
     return(.x)
   }
-  
+
   emissionsReport <- mbind(
     emissionsReport,
     .generateGWPCH4("GWP100AR6"),
     .generateGWPCH4("GWP*AR6")
   )
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # Total yearly CO2e (for GWP100AR6) emissions reporting
-  
+
   .generateTotalGWP <- function(.unit) {
     reports <- c(paste0("Emissions|CH4_", .unit, "|Land (Mt CO2e/yr)"),
                  paste0("Emissions|N2O_", .unit, "|Land (Mt CO2e/yr)"),
                  "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)")
-    
+
     total <- dimSums(emissionsReport[, , reports], dim = 3) * 0.001 # Mt to Gt CO2e
     total <- setNames(total, paste0("Emissions|", .unit, "|Land (Gt CO2e/yr)"))
-    
+
     return(total)
   }
-  
+
   emissionsReport <- mbind(
     emissionsReport,
     .generateTotalGWP("GWP100AR6")
   )
-  
-  
+
+
   # -----------------------------------------------------------------------------------------------------------------
   # Total cumulative CO2e (for GWP100AR6) emissions reporting
-  
+
   .generateCumulativeGWP <- function(.unit) {
-    
+
     years <- getYears(emissionsReport, as.integer = TRUE)
-    
+
     # accumulate flow reports (CH4, N2O)
     flows <- emissionsReport[, , c(paste0("Emissions|CH4_", .unit, "|Land (Mt CO2e/yr)"),
                                    paste0("Emissions|N2O_", .unit, "|Land (Mt CO2e/yr)"))]
     flows <- flows[, years, ]
     flows[, c("y1995", "y2000"), ] <- 0
-    
+
     flows <- time_interpolate(flows, interpolated_year = min(years):max(years))
     flows <- as.magpie(apply(flows, c(1, 3), cumsum))
     flows <- flows[, years, ]
-    
+
     # accumulate stock reports (CO2)
     stock <- emissionsReport[, , "Emissions|CO2|Land|+|Land-use Change (Mt CO2/yr)"]
     stock <- stock[, years, ]
     stock[, c("y1995", "y2000"), ] <- 0
-    
+
     im_years <- m_yeardiff(gdx)[, years, ]
     stock <- stock * im_years
     stock <- as.magpie(apply(stock, c(1, 3), cumsum))
-    
+
     # combine accounting of stocks and flows
     all <- setNames(stock, NULL) + dimSums(flows, dim = 3)
     all <- all * 0.001  # Mt to Gt CO2e
     all <- setNames(all, paste0("Emissions|", .unit, "|Land|Cumulative (Gt CO2e)"))
-    
+
     all[, "y1995", ] <- NA
-    
+
     return(all)
   }
-  
+
   emissionsReport <- mbind(
     emissionsReport,
     .generateCumulativeGWP("GWP100AR6")
   )
-  
+
   return(emissionsReport)
-  
+
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **2.1.0**
+R package **magpie4**, version **2.2.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magpie4)](https://cran.r-project.org/package=magpie4) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M (2024). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi: 10.5281/zenodo.1158582 (URL: https://doi.org/10.5281/zenodo.1158582), R package version 2.1.0, <URL: https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M (2024). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, R package version 2.2.0, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,8 +48,8 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves},
   year = {2024},
-  note = {R package version 2.1.0},
-  doi = {10.5281/zenodo.1158582},
+  note = {R package version 2.2.0},
   url = {https://github.com/pik-piam/magpie4},
+  doi = {10.5281/zenodo.1158582},
 }
 ```

--- a/man/emisCO2.Rd
+++ b/man/emisCO2.Rd
@@ -13,8 +13,7 @@ emisCO2(
   sum_land = TRUE,
   cumulative = FALSE,
   baseyear = 1995,
-  lowpass = 3,
-  stock = NULL
+  lowpass = 3
 )
 }
 \arguments{
@@ -45,8 +44,6 @@ cumulative emissions is y1995.}
 \item{baseyear}{Baseyear used for cumulative emissions (default = 1995)}
 
 \item{lowpass}{number of lowpass filter iterations (default = 3)}
-
-\item{stock}{Carbon stocks. If NULL, carbonstock function is called instead.}
 }
 \value{
 CO2 emissions as MAgPIE object (unit depends on \code{unit})
@@ -58,8 +55,7 @@ reads detailed CO2 emissions out of a MAgPIE gdx file
 \dontrun{
 x <- emisCO2(gdx)
 }
-
 }
 \author{
-Florian Humpenoeder
+Florian Humpenoeder, Michael Crawford
 }


### PR DESCRIPTION
This is a complete re-write of emisCO2.R. The calculations of gross emissions (deforestation, degradation, other land conversion and harvesting emissions), are now fully aligned with the area-based emissions as one would calculate through tracking only the changes in land type areas multiplied by their carbon densities over time. The calculation for these "main emissions" is also improved, as it incorporates the "interaction emissions" which emerge when changes in land area and carbon densities influence one another. These are a relatively small source of emissions, roughly 0.1-1% compared to area emissions (land-use emissions). Aside from the inclusion of these, the main emissions haven't changed between implementations of emisCO2.R.

I have a series of plots generated from a suite of scenarios factorially switching forestry, degradation, CO2 afforestation, climate change, and SOM. Please find them attached to this PR, here: [plots.zip](https://github.com/pik-piam/magpie4/files/15224751/plots.zip). Of key importance for judging inconsistencies in the new approach will be the "residual emissions", between our total land use emissions (`emisArea`) and the sum of regrowth and gross emissions. The function now checks to ensure that these residual unaccounted for emissions are less that 1e-06. It also ensures that the stock derivation of carbonstock (which uses the raw carbon densities ov_carbon_stock) is roughly equal to our independent calculation. The check for this has to be cut off at 1e-05, because of one cell in REF. I'm eager to discuss further checks you might devise.

@ Kristine, I mainly want you to check the implementation of the SOM module's CO2 emissions. Mostly, I've just separated the calculation into first generating the areas and then the carbon densities. You'll therefore want to in particularly attend to the composeDensity function. Notably, in my checks I found that pastures' SOM were not synchronized with the actual output of MAgPIE's carbonstock function. After Florian investigated further, we found that the implementation of SOM in the older emisCO2.R function was out of sync with the actual static SOM module implementation. In the actual implementation, the soil carbon in pasture is derived from `fm_carbon_density`. Therefore, I updated that here. Everything else should be the same. Since we don't have any mechanistic gross emission categories for SOM (like vegc has deforestation, e.g.), I'm attaching the "main emissions" for SOM to the "gross emissions" to make them match. You might also look at SOM emissions for a few choice scenarios (perhaps just SOM ON/SOM OFF) within the disaggregated emissions plots to make sure that they look reasonable. Something I'm interested to know, is whether you would expect the net SOM emissions to mostly be 0.

You might also see some commented code relating to `croptreecover`, which is ongoing with Florian. I wanted to get this PR through before confronting those changes, so for now they will be comments.