### PR TITLE
check cell instead of first col in addGeometry

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '50033628'
+ValidationKey: '50061075'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 2.5.14
-date-released: '2024-06-28'
+version: 2.5.15
+date-released: '2024-07-01'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 2.5.14
-Date: 2024-06-28
+Version: 2.5.15
+Date: 2024-07-01
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/addGeometry.R
+++ b/R/addGeometry.R
@@ -6,7 +6,7 @@
 #' @param x Landuse data on cluster/cell resolution as a magclass object
 #' @param clustermap A dataframe mapping with columns cluster, cell, and country
 #' @return A magclass object enriched with geometry information
-#' @author Jan Philipp Dietrich
+#' @author Jan Philipp Dietrich, Pascal Sauer
 #' @examples
 #' \dontrun{
 #' landUse <- magpie4::land("fulldata.gdx", level = "cell")
@@ -26,8 +26,10 @@ addGeometry <- function(x, clustermap) {
   clusterMagclass <- madrat::toolAggregate(clusterMagclass, clustermap, from = "cluster", to = "cell")
   # 67k clustermap has cells like "-179p75.-16p25.FJI", but after toolAggregate dimnames for dim 1 are
   # "region.region1" despite there being 3 subdimensions & as.SpatRaster expects coordinate subdims to be called x/y
-  if (all(grepl("\\..+\\.[A-Z]{3}", clustermap[[1]]))) {
+  if (all(grepl("^-?[0-9p]+\\.-?[0-9p]+\\.[A-Z]{3}$", clustermap[["cell"]]))) {
     names(dimnames(clusterMagclass))[1] <- "x.y.country"
+  } else if (all(grepl("^-?[0-9p]+\\.-?[0-9p]+$", clustermap[["cell"]]))) {
+    names(dimnames(clusterMagclass))[1] <- "x.y"
   }
   clusterPolygons <- terra::as.polygons(magclass::as.SpatRaster(clusterMagclass))
   terra::crs(clusterPolygons) <- "+proj=longlat +datum=WGS84 +no_defs"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **2.5.14**
+R package **magpie4**, version **2.5.15**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magpie4)](https://cran.r-project.org/package=magpie4) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M (2024). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, R package version 2.5.14, <https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M (2024). _magpie4: MAgPIE outputs R package for MAgPIE version 4.x_. doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, R package version 2.5.15, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,8 +48,8 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves},
   year = {2024},
-  note = {R package version 2.5.14},
-  doi = {10.5281/zenodo.1158582},
+  note = {R package version 2.5.15},
   url = {https://github.com/pik-piam/magpie4},
+  doi = {10.5281/zenodo.1158582},
 }
 ```

--- a/man/addGeometry.Rd
+++ b/man/addGeometry.Rd
@@ -29,5 +29,5 @@ attr(landUseEnriched, "crs")
 
 }
 \author{
-Jan Philipp Dietrich
+Jan Philipp Dietrich, Pascal Sauer
 }


### PR DESCRIPTION
addGeometry was assuming "cell" to be the first column which is not necessary. It now also works if "cell" only has coords like "-5p03.3p22" instead of the full "-5p03.3p22.FJI". This is used in mrdownscale.