### PR TITLE
Partialmatch fix

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '44777201'
+ValidationKey: '446157690'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 2.21.9
+version: 2.21.10
 date-released: '2025-04-01'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 2.21.9
+Version: 2.21.10
 Date: 2025-04-01
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/CropareaDiversityIndex.R
+++ b/R/CropareaDiversityIndex.R
@@ -130,7 +130,7 @@ CropareaDiversityIndex <- function(gdx, index="shannon", level = "reg", measurel
   }
 
   out <- gdxAggregate(gdx, x, to = level,
-                      weight = "land", type = "crop", absolute = FALSE,
+                      weight = "land", types = "crop", absolute = FALSE,
                       dir = dir)
   return(out)
 }

--- a/R/productionProfit.R
+++ b/R/productionProfit.R
@@ -28,7 +28,7 @@ productionProfit <- function(gdx, file=NULL, level="reg", dir="."){
   
   x <- revenue - cost 
   
-  out <- gdxAggregate(gdx,x,to=level,weight="land",type="crop",absolute = T,
+  out <- gdxAggregate(gdx,x,to=level,weight="land",types="crop",absolute = T,
                       dir = dir)
   
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **2.21.9**
+R package **magpie4**, version **2.21.10**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magpie4)](https://cran.r-project.org/package=magpie4) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Bonsch M, Vartika S (2025). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.21.9, <https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Bonsch M, Vartika S (2025). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.21.10, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -51,6 +51,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-04-01},
   year = {2025},
   url = {https://github.com/pik-piam/magpie4},
-  note = {Version: 2.21.9},
+  note = {Version: 2.21.10},
 }
 ```


### PR DESCRIPTION
`gdxAggregate()` still had two partial matches of `type` in function calls to the `types` parameter.