### PR TITLE
Makes calibration archive creation more resilient

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '55852480'
+ValidationKey: '55875735'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 2.72.0
-date-released: '2026-03-22'
+version: 2.72.1
+date-released: '2026-03-23'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 2.72.0
-Date: 2026-03-22
+Version: 2.72.1
+Date: 2026-03-23
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/submitCalibration.R
+++ b/R/submitCalibration.R
@@ -18,22 +18,25 @@
 #' }
 #' @export
 
-submitCalibration <- function(name, file = c("modules/14_yields/input/f14_yld_calib.csv", "modules/39_landconversion/input/f39_calib.cs3"), archive = "/p/projects/landuse/data/input/calibration") {
+submitCalibration <- function(name,
+  file = c("modules/14_yields/input/f14_yld_calib.csv", "modules/39_landconversion/input/f39_calib.cs3"),
+  archive = "/p/projects/landuse/data/input/calibration"
+) {
   if (!all(unique(file_ext(file)) %in% c("csv", "cs3", "gdx"))) {
     stop("Different file types are not supported!")
   } else {
     ftype <- unique(file_ext(file))
-    if ("gdx" %in% ftype & length(ftype) == 1) {
+    if ("gdx" %in% ftype && length(ftype) == 1) {
       d <- readGDX(file, "f14_yld_calib", react = "silent")
       e <- readGDX(file, "f39_calib", react = "silent")
     } else if (any(c("csv", "cs3") %in% ftype) & length(ftype) <= 2) {
-      if(file.exists(file[1])) {
+      if (file.exists(file[1])) {
         d <- read.magpie(file[1])
       } else {
         d <- NULL
         warning(paste("File", file[1], "not found!"))
       }
-      if (!is.na(file[2]) & file.exists(file[2])) {
+      if (!is.na(file[2]) && file.exists(file[2])) {
         e <- read.magpie(file[2])
       } else if (!is.na(file[2]) & file.exists(gsub("cs3", "csv", file[2]))) {
         e <- read.magpie(gsub("cs3", "csv", file[2]))
@@ -50,9 +53,9 @@ submitCalibration <- function(name, file = c("modules/14_yields/input/f14_yld_ca
       i <- i + 1
       fname <- format(Sys.time(), paste0("calibration_", name, "_%d%b%y_", i, ".tgz"))
     }
-    tdir <- tempdir()
-    unlink(paste0(tdir, "/*"))
-    if(!is.null(d)) {
+    tdir <- file.path(tempdir(), paste0(sample(letters, 20, replace = TRUE), collapse = ""))
+    dir.create(tdir, showWarnings = FALSE)
+    if (!is.null(d)) {
       write.magpie(d, paste0(tdir, "/f14_yld_calib.csv"))
     }
     if (!is.null(e)) {
@@ -63,6 +66,7 @@ submitCalibration <- function(name, file = c("modules/14_yields/input/f14_yld_ca
       }
     }
     tardir(tdir, tarfile = paste0(archive, "/", fname))
+    unlink(tdir, recursive = TRUE)
     return(fname)
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **2.72.0**
+R package **magpie4**, version **2.72.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magpie4)](https://cran.r-project.org/package=magpie4) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.72.0, <https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.72.1, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves and Pascal Sauer and Markus Bonsch and Singh Vartika and Patrick Rein},
   doi = {10.5281/zenodo.1158582},
-  date = {2026-03-22},
+  date = {2026-03-23},
   year = {2026},
   url = {https://github.com/pik-piam/magpie4},
-  note = {Version: 2.72.0},
+  note = {Version: 2.72.1},
 }
 ```


### PR DESCRIPTION
Makes calibration archive creation more resilient by doing the packaging in a dedicated tmp folder instead of the session tmp folder.

This became relevant, as sometimes calibration folders contain funny data from other activities in the session tmp folder.