### PR TITLE
Fix natural-origin secdforest correction to preserve emisNet identity

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '56732400'
+ValidationKey: '56755755'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 2.75.4
-date-released: '2026-05-27'
+version: 2.75.5
+date-released: '2026-05-28'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 2.75.4
-Date: 2026-05-27
+Version: 2.75.5
+Date: 2026-05-28
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/embodiedLand.R
+++ b/R/embodiedLand.R
@@ -26,12 +26,12 @@
 #'
 #' @return Embodied land use as MAgPIE object.
 #'   When bilateral=FALSE and disaggLivestock=FALSE: dim 3 = accounting.product (2 subdims).
-#'   When bilateral=FALSE and disaggLivestock=TRUE: dim 3 = accounting.{prim,secd,kli_*}.product
+#'   When bilateral=FALSE and disaggLivestock=TRUE: dim 3 = accounting.\{prim,secd,kli_*\}.product
 #'   (3 subdims); production/consumption have prim = crop+pasture land and kli_* = feed
 #'   chain land per animal product (secd=0 in production); trade types retain the full
 #'   secd pathway. Note: prim and kli_* items overlap (feed crops appear in both), so
 #'   they should not be summed — use one or the other for attribution.
-#'   When bilateral=TRUE: dim 3 = {prim,secd,kli_*}.product (pathway.product).
+#'   When bilateral=TRUE: dim 3 = \{prim,secd,kli_*\}.product (pathway.product).
 #' @author David M Chen
 #' @seealso \code{\link{land}}, \code{\link{croparea}}, \code{\link{trade}}
 #' @importFrom magclass collapseNames mbind dimSums dimOrder setNames getNames getItems getYears add_dimension getRegions new.magpie

--- a/R/emisCO2.R
+++ b/R/emisCO2.R
@@ -335,24 +335,29 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
 
             # Stock correction = natural × gap (per ac, sum)
             stockCorrVeg <- dimSums(natRaw * gapVeg, dim = 3)             # (j,t)
-            tDiffNat     <- natRaw
+
+            # Decompose tDiff(natRaw * gapVeg) into the three Bennet-style components
+            # so that the correction is consistently applied to emisArea, emisCC and
+            # emisInteract — preserving the identity emisNet = emisCC + emisArea + emisInteract.
+            tDiffNat <- natRaw
             tDiffNat[, , ] <- 0
+            tDiffGap <- gapVeg
+            tDiffGap[, , ] <- 0
             for (i in 2:nyears(natRaw)) {
                 tDiffNat[, i, ] <- setYears(natRaw[, i - 1, ], getYears(natRaw[, i, ])) - natRaw[, i, ]
+                tDiffGap[, i, ] <- setYears(gapVeg[, i - 1, ], getYears(gapVeg[, i, ])) - gapVeg[, i, ]
             }
-            tDiffStockCorrVeg <- natRaw
-            tDiffStockCorrVeg[, , ] <- 0
-            tmp <- natRaw * gapVeg
-            for (i in 2:nyears(tmp)) {
-                tDiffStockCorrVeg[, i, ] <- setYears(tmp[, i - 1, ], getYears(tmp[, i, ])) - tmp[, i, ]
-            }
-            tDiffStockCorrVegSum <- dimSums(tDiffStockCorrVeg, dim = 3)
-            emisAreaCorrVeg      <- dimSums(tDiffNat * gapVeg, dim = 3)
+            emisAreaCorrVeg     <- dimSums(tDiffNat * gapVeg,  dim = 3)   # area effect
+            emisCcCorrVeg       <- dimSums(natRaw   * tDiffGap, dim = 3)  # density effect
+            emisInteractCorrVeg <- dimSums(tDiffNat * tDiffGap, dim = 3)  # interaction
+            tDiffStockCorrVegSum <- emisAreaCorrVeg + emisCcCorrVeg + emisInteractCorrVeg
 
             # Apply only to vegc slice of the secdforest stock/emis containers
-            totalStock$secdforest[, , "secdforest.vegc"] <- totalStock$secdforest[, , "secdforest.vegc"] - stockCorrVeg
-            emisNet$secdforest[, , "secdforest.vegc"]    <- emisNet$secdforest[, , "secdforest.vegc"]    - tDiffStockCorrVegSum
-            emisArea$secdforest[, , "secdforest.vegc"]   <- emisArea$secdforest[, , "secdforest.vegc"]   - emisAreaCorrVeg
+            totalStock$secdforest[, , "secdforest.vegc"]   <- totalStock$secdforest[, , "secdforest.vegc"]   - stockCorrVeg
+            emisNet$secdforest[, , "secdforest.vegc"]      <- emisNet$secdforest[, , "secdforest.vegc"]      - tDiffStockCorrVegSum
+            emisArea$secdforest[, , "secdforest.vegc"]     <- emisArea$secdforest[, , "secdforest.vegc"]     - emisAreaCorrVeg
+            emisCC$secdforest[, , "secdforest.vegc"]       <- emisCC$secdforest[, , "secdforest.vegc"]       - emisCcCorrVeg
+            emisInteract$secdforest[, , "secdforest.vegc"] <- emisInteract$secdforest[, , "secdforest.vegc"] - emisInteractCorrVeg
         }
 
         mainEmissions <- list(totalStock   = totalStock,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **2.75.4**
+R package **magpie4**, version **2.75.5**
 
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.75.4, <https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.75.5, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves and Pascal Sauer and Markus Bonsch and Singh Vartika and Patrick Rein},
   doi = {10.5281/zenodo.1158582},
-  date = {2026-05-27},
+  date = {2026-05-28},
   year = {2026},
   url = {https://github.com/pik-piam/magpie4},
-  note = {Version: 2.75.4},
+  note = {Version: 2.75.5},
 }
 ```

--- a/man/embodiedLand.Rd
+++ b/man/embodiedLand.Rd
@@ -46,12 +46,12 @@ Default is FALSE (current behaviour: feed attributed to crops).}
 \value{
 Embodied land use as MAgPIE object.
   When bilateral=FALSE and disaggLivestock=FALSE: dim 3 = accounting.product (2 subdims).
-  When bilateral=FALSE and disaggLivestock=TRUE: dim 3 = accounting.{prim,secd,kli_*}.product
+  When bilateral=FALSE and disaggLivestock=TRUE: dim 3 = accounting.\{prim,secd,kli_*\}.product
   (3 subdims); production/consumption have prim = crop+pasture land and kli_* = feed
   chain land per animal product (secd=0 in production); trade types retain the full
   secd pathway. Note: prim and kli_* items overlap (feed crops appear in both), so
   they should not be summed — use one or the other for attribution.
-  When bilateral=TRUE: dim 3 = {prim,secd,kli_*}.product (pathway.product).
+  When bilateral=TRUE: dim 3 = \{prim,secd,kli_*\}.product (pathway.product).
 }
 \description{
 Calculates production-based and consumption-based (embodied) land footprint 


### PR DESCRIPTION
PR #130 patched totalStock, emisNet and emisArea for the natural-origin density split but left emisCC and emisInteract untouched, breaking the algebraic identity emisNet = emisCC + emisArea + emisInteract for secdforest.vegc whenever the calibrated/uncalibrated density gap evolves in time (i.e. any post-#876 multi-year run with CC on). The residual fires .validateCalculation's "main emissions" warning and grows to multi-Mt-C/cell-yr by 2100.

Apply the full Bennet decomposition of tDiff(n*gap) to all three emission components instead of only the area piece:

  tDiff(n*gap) = tDiff(n)*gap + n*tDiff(gap) + tDiff(n)*tDiff(gap)
                                      area          density        interaction

tDiffStockCorrVegSum is now defined as the sum of the three component corrections rather than computed independently, so the emisNet correction matches the component corrections by construction.