### PR TITLE
Fix/try list masked warnings

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '56755755'
+ValidationKey: '56861520'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 2.75.5
-date-released: '2026-05-28'
+version: 2.76.0
+date-released: '2026-05-29'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 2.75.5
-Date: 2026-05-28
+Version: 2.76.0
+Date: 2026-05-29
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/tryList.R
+++ b/R/tryList.R
@@ -34,7 +34,7 @@ tryList <- function(..., gdx, level = "regglo") {
   # rethrow warnings, we lose the stack trace but get the warning nevertheless
   for (cond in conditions) {
     if (cond$type == "warning") {
-      for (warn in cond$result) {
+      for (warn in cond$warnings) {
         warning(warn)
       }
     }

--- a/R/tryList.R
+++ b/R/tryList.R
@@ -31,6 +31,15 @@ tryList <- function(..., gdx, level = "regglo") {
     message("   ", format(cond$reportExpr, width = width), cond$message, cond$elapsed)
   }
 
+  # rethrow warnings, we lose the stack trace but get the warning nevertheless
+  for (cond in conditions) {
+    if (cond$type == "warning") {
+      for (warn in cond$result) {
+        warning(warn)
+      }
+    }
+  }
+
   return(lapply(conditions, function(cond) {
     cond$result
   }))

--- a/R/tryReport.R
+++ b/R/tryReport.R
@@ -32,16 +32,38 @@ tryReport <- function(report, gdx, level = "regglo", env = parent.frame()) {
   }
 
   years <- readGDX(gdx, "t")
-  t <- system.time(x <- try(eval(parse(text = paste0("suppressMessages(", report, ")")), env),
-                            silent = TRUE))
+  gatheredWarnings <- c()
+  # todo: check how weekly tests check for errors
+  t <- system.time(
+    x <- tryCatch(
+      withCallingHandlers(
+        eval(parse(text = paste0("suppressMessages(", report, ")")), env),
+        warning = function(warn) {
+          # The following assignment is necessary to access the gatheredWarnings
+          # in the tryReport context.
+          gatheredWarnings <<- c(gatheredWarnings, list(warn)) #nolint: undesireable_operator_linter
+          invokeRestart("muffleWarning")
+        }
+      ),
+      error = function(err) {
+        return(err)
+      }
+    )
+  )
   elapsed <- t["elapsed"]
 
-  cond <- if (is(x, "try-error")) {
-    reportError(report, elapsed, x)
+  cond <- if (inherits(x, "error")) {
+    reportError(report, elapsed, conditionMessage(x))
+  } else if (length(gatheredWarnings) > 0) {
+    reportWarning(report,
+                  elapsed,
+                  paste0(length(gatheredWarnings), " warnings, first: ",
+                         conditionMessage(gatheredWarnings[[1]])),
+                  gatheredWarnings)
   } else if (is.null(x)) {
-    reportWarning(report, elapsed, "no return value")
+    reportWarning(report, elapsed, "no return value", gatheredWarnings)
   } else if (is.character(x)) {
-    reportWarning(report, elapsed, x)
+    reportWarning(report, elapsed, x, gatheredWarnings)
   } else if (!is.magpie(x)) {
     reportValidationError(report, elapsed, "no magpie object")
   } else if (!setequal(getYears(x), years)) {
@@ -93,6 +115,6 @@ reportValidationError <- function(reportExpr, elapsed, reason) {
   reportResult("validationError", msg, reportExpr, elapsed)
 }
 
-reportWarning <- function(reportExpr, elapsed, reason) {
-  reportResult("warning", reason, reportExpr, elapsed)
+reportWarning <- function(reportExpr, elapsed, reason, gatheredWarnings) {
+  reportResult("warning", reason, reportExpr, elapsed, gatheredWarnings)
 }

--- a/R/tryReport.R
+++ b/R/tryReport.R
@@ -115,6 +115,8 @@ reportValidationError <- function(reportExpr, elapsed, reason) {
   reportResult("validationError", msg, reportExpr, elapsed)
 }
 
-reportWarning <- function(reportExpr, elapsed, reason, gatheredWarnings) {
-  reportResult("warning", reason, reportExpr, elapsed, gatheredWarnings)
+reportWarning <- function(reportExpr, elapsed, reason, gatheredWarnings = c()) {
+  warnReport <- reportResult("warning", reason, reportExpr, elapsed)
+  warnReport$warnings <- gatheredWarnings
+  return(warnReport)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **2.75.5**
+R package **magpie4**, version **2.76.0**
 
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.75.5, <https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.76.0, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves and Pascal Sauer and Markus Bonsch and Singh Vartika and Patrick Rein},
   doi = {10.5281/zenodo.1158582},
-  date = {2026-05-28},
+  date = {2026-05-29},
   year = {2026},
   url = {https://github.com/pik-piam/magpie4},
-  note = {Version: 2.75.5},
+  note = {Version: 2.76.0},
 }
 ```

--- a/man/addGeometry.Rd
+++ b/man/addGeometry.Rd
@@ -29,11 +29,11 @@ attr(landUseEnriched, "crs")
 
 }
 \seealso{
-Other Spatial: 
-\code{\link{clusterOutputToTerraVector}()},
-\code{\link{gdxAggregate}()},
-\code{\link{mappingToLongFormat}()},
-\code{\link{superAggregateX}()}
+Other Spatial:
+\code{\link[=clusterOutputToTerraVector]{clusterOutputToTerraVector()}},
+\code{\link[=gdxAggregate]{gdxAggregate()}},
+\code{\link[=mappingToLongFormat]{mappingToLongFormat()}},
+\code{\link[=superAggregateX]{superAggregateX()}}
 }
 \author{
 Jan Philipp Dietrich, Pascal Sauer

--- a/man/addToDataChangelog.Rd
+++ b/man/addToDataChangelog.Rd
@@ -39,9 +39,9 @@ Invisibly, the written changelog as data.frame
 Prepend data from the given report to the changelog.
 }
 \seealso{
-Other Data Changelog: 
-\code{\link{changelogVariables}()},
-\code{\link{changelogYears}()}
+Other Data Changelog:
+\code{\link[=changelogVariables]{changelogVariables()}},
+\code{\link[=changelogYears]{changelogYears()}}
 }
 \author{
 Pascal Sauer

--- a/man/changelogVariables.Rd
+++ b/man/changelogVariables.Rd
@@ -10,9 +10,9 @@ changelogVariables()
 Returns a named vector of variables to put into the data changelog, see \code{\link{addToDataChangelog}}.
 }
 \seealso{
-Other Data Changelog: 
-\code{\link{addToDataChangelog}()},
-\code{\link{changelogYears}()}
+Other Data Changelog:
+\code{\link[=addToDataChangelog]{addToDataChangelog()}},
+\code{\link[=changelogYears]{changelogYears()}}
 }
 \author{
 Pascal Sauer

--- a/man/changelogYears.Rd
+++ b/man/changelogYears.Rd
@@ -10,9 +10,9 @@ changelogYears()
 Returns the years to put into the data changelog, see \code{\link{addToDataChangelog}}.
 }
 \seealso{
-Other Data Changelog: 
-\code{\link{addToDataChangelog}()},
-\code{\link{changelogVariables}()}
+Other Data Changelog:
+\code{\link[=addToDataChangelog]{addToDataChangelog()}},
+\code{\link[=changelogVariables]{changelogVariables()}}
 }
 \author{
 Pascal Sauer

--- a/man/clusterOutputToTerraVector.Rd
+++ b/man/clusterOutputToTerraVector.Rd
@@ -28,11 +28,11 @@ terra::writeVector(clusterPolygons, "cluster_resolution.shp")
 
 }
 \seealso{
-Other Spatial: 
-\code{\link{addGeometry}()},
-\code{\link{gdxAggregate}()},
-\code{\link{mappingToLongFormat}()},
-\code{\link{superAggregateX}()}
+Other Spatial:
+\code{\link[=addGeometry]{addGeometry()}},
+\code{\link[=gdxAggregate]{gdxAggregate()}},
+\code{\link[=mappingToLongFormat]{mappingToLongFormat()}},
+\code{\link[=superAggregateX]{superAggregateX()}}
 }
 \author{
 Pascal Führlich, Patrick v. Jeetze

--- a/man/expectVariablesPresent.Rd
+++ b/man/expectVariablesPresent.Rd
@@ -21,11 +21,11 @@ Checks whether a set of expected variable names is present in a
   are removed.
 }
 \seealso{
-Other Infrastructure: 
-\code{\link{metadata_comments}()},
-\code{\link{out}()},
-\code{\link{tryList}()},
-\code{\link{tryReport}()}
+Other Infrastructure:
+\code{\link[=metadata_comments]{metadata_comments()}},
+\code{\link[=out]{out()}},
+\code{\link[=tryList]{tryList()}},
+\code{\link[=tryReport]{tryReport()}}
 }
 \author{
 Patrick Rein

--- a/man/gdxAggregate.Rd
+++ b/man/gdxAggregate.Rd
@@ -40,11 +40,11 @@ gdp_glo <- gdxAggregate(gdx = gdx, x = gdp, weight = "population", to = "glo", a
 }
 }
 \seealso{
-Other Spatial: 
-\code{\link{addGeometry}()},
-\code{\link{clusterOutputToTerraVector}()},
-\code{\link{mappingToLongFormat}()},
-\code{\link{superAggregateX}()}
+Other Spatial:
+\code{\link[=addGeometry]{addGeometry()}},
+\code{\link[=clusterOutputToTerraVector]{clusterOutputToTerraVector()}},
+\code{\link[=mappingToLongFormat]{mappingToLongFormat()}},
+\code{\link[=superAggregateX]{superAggregateX()}}
 }
 \author{
 Benjamin Leon Bodirsky, Edna J. Molina Bacca, Florian Humpenoeder

--- a/man/mappingToLongFormat.Rd
+++ b/man/mappingToLongFormat.Rd
@@ -34,11 +34,11 @@ formulas that we could use in madrat functions. If the magpie4 aggregation logic
 is ever rewritten, this function may become obsolete.
 }
 \seealso{
-Other Spatial: 
-\code{\link{addGeometry}()},
-\code{\link{clusterOutputToTerraVector}()},
-\code{\link{gdxAggregate}()},
-\code{\link{superAggregateX}()}
+Other Spatial:
+\code{\link[=addGeometry]{addGeometry()}},
+\code{\link[=clusterOutputToTerraVector]{clusterOutputToTerraVector()}},
+\code{\link[=gdxAggregate]{gdxAggregate()}},
+\code{\link[=superAggregateX]{superAggregateX()}}
 }
 \author{
 Kristine Karstens, Patrick Rein

--- a/man/metadata_comments.Rd
+++ b/man/metadata_comments.Rd
@@ -31,11 +31,11 @@ set metadata comments to magpie4 objects
 
 }
 \seealso{
-Other Infrastructure: 
-\code{\link{expectVariablesPresent}()},
-\code{\link{out}()},
-\code{\link{tryList}()},
-\code{\link{tryReport}()}
+Other Infrastructure:
+\code{\link[=expectVariablesPresent]{expectVariablesPresent()}},
+\code{\link[=out]{out()}},
+\code{\link[=tryList]{tryList()}},
+\code{\link[=tryReport]{tryReport()}}
 }
 \author{
 Benjamin Bodirsky, Jannes Breier

--- a/man/out.Rd
+++ b/man/out.Rd
@@ -21,11 +21,11 @@ writes it to a file. Please use this function when you write own GDX output
 functions.
 }
 \seealso{
-Other Infrastructure: 
-\code{\link{expectVariablesPresent}()},
-\code{\link{metadata_comments}()},
-\code{\link{tryList}()},
-\code{\link{tryReport}()}
+Other Infrastructure:
+\code{\link[=expectVariablesPresent]{expectVariablesPresent()}},
+\code{\link[=metadata_comments]{metadata_comments()}},
+\code{\link[=tryList]{tryList()}},
+\code{\link[=tryReport]{tryReport()}}
 }
 \author{
 Jan Philipp Dietrich

--- a/man/superAggregateX.Rd
+++ b/man/superAggregateX.Rd
@@ -37,11 +37,11 @@ object.
 drop-in replacement for superAggregate based on toolAggregate
 }
 \seealso{
-Other Spatial: 
-\code{\link{addGeometry}()},
-\code{\link{clusterOutputToTerraVector}()},
-\code{\link{gdxAggregate}()},
-\code{\link{mappingToLongFormat}()}
+Other Spatial:
+\code{\link[=addGeometry]{addGeometry()}},
+\code{\link[=clusterOutputToTerraVector]{clusterOutputToTerraVector()}},
+\code{\link[=gdxAggregate]{gdxAggregate()}},
+\code{\link[=mappingToLongFormat]{mappingToLongFormat()}}
 }
 \author{
 Jan Philipp Dietrich

--- a/man/tryList.Rd
+++ b/man/tryList.Rd
@@ -23,11 +23,11 @@ a \code{\link{tryReport}} environment.
 \seealso{
 \code{\link{tryReport}}, \code{\link{reportResult}}
 
-Other Infrastructure: 
-\code{\link{expectVariablesPresent}()},
-\code{\link{metadata_comments}()},
-\code{\link{out}()},
-\code{\link{tryReport}()}
+Other Infrastructure:
+\code{\link[=expectVariablesPresent]{expectVariablesPresent()}},
+\code{\link[=metadata_comments]{metadata_comments()}},
+\code{\link[=out]{out()}},
+\code{\link[=tryReport]{tryReport()}}
 }
 \author{
 Jan Philipp Dietrich

--- a/man/tryReport.Rd
+++ b/man/tryReport.Rd
@@ -27,11 +27,11 @@ further processing in case of an error.
 \seealso{
 \code{\link{reportResult}}
 
-Other Infrastructure: 
-\code{\link{expectVariablesPresent}()},
-\code{\link{metadata_comments}()},
-\code{\link{out}()},
-\code{\link{tryList}()}
+Other Infrastructure:
+\code{\link[=expectVariablesPresent]{expectVariablesPresent()}},
+\code{\link[=metadata_comments]{metadata_comments()}},
+\code{\link[=out]{out()}},
+\code{\link[=tryList]{tryList()}}
 }
 \author{
 Jan Philipp Dietrich

--- a/tests/testthat/test-tryList.R
+++ b/tests/testthat/test-tryList.R
@@ -1,0 +1,54 @@
+test_that("tryList prints the warning result message from tryReport", {
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c())
+    }
+  )
+
+  myReportFunction <- function() {
+    warning("my warning message")
+    return(new.magpie(c("AFR", "CPA", "GLO")))
+  }
+
+  printedMessages <- c()
+
+  withCallingHandlers(
+    suppressWarnings(tryList("myReportFunction()", gdx = "")),
+    message = function(m) {
+      printedMessages <<- c(printedMessages, conditionMessage(m)) #nolint: undesireable_operator_linter
+      invokeRestart("muffleMessage")
+    }
+  )
+
+  expect_true(any(grepl("1 warnings, first: my warning message", printedMessages)))
+})
+
+test_that("tryList rethrows one warning per warning thrown inside a report function", {
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c())
+    }
+  )
+
+  myReportFunction <- function() {
+    warning("Warning 1")
+    warning("Warning 2")
+    return(new.magpie(c("AFR", "CPA", "GLO")))
+  }
+
+  caughtWarnings <- c()
+
+  withCallingHandlers(
+    suppressMessages(tryList("myReportFunction()", gdx = "")),
+    warning = function(w) {
+      caughtWarnings <<- c(caughtWarnings, conditionMessage(w)) #nolint: undesireable_operator_linter
+      invokeRestart("muffleWarning")
+    }
+  )
+
+  expect_length(caughtWarnings, 2)
+  expect_true(any(grepl("Warning 1", caughtWarnings)))
+  expect_true(any(grepl("Warning 2", caughtWarnings)))
+})

--- a/tests/testthat/test-tryReport.R
+++ b/tests/testthat/test-tryReport.R
@@ -1,5 +1,88 @@
-test_that("tryReport validates the regions returned by a report function", {
+test_that("tryReport returns error when report throws an error", {
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c())
+    }
+  )
+  myReportFunction <- function() stop("something went wrong")
+  result <- tryReport("myReportFunction()", "")
+  expect_equal(result[["type"]], "error")
+  expect_match(result[["message"]], "ERROR")
+})
+
+test_that("tryReport returns warning when report returns NULL", {
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c())
+    }
+  )
+  myReportFunction <- function() return(NULL)
+  result <- tryReport("myReportFunction()", "")
+  expect_equal(result[["type"]], "warning")
+  expect_equal(result[["message"]], "no return value")
+})
+
+test_that("tryReport returns warning when report returns a character vector", {
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c())
+    }
+  )
+  myReportFunction <- function() return("Warning 1")
+  result <- tryReport("myReportFunction()", "")
+  expect_equal(result[["type"]], "warning")
+  expect_equal(result[["message"]], "Warning 1")
+})
+
+test_that("tryReport returns warning result when report returns a warning", {
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c())
+    }
+  )
+  myReportFunction <- function() {
+    warning("Warning 1")
+    warning("Warning 2")
+    return(new.magpie(c("AFR", "CPA", "GLO")))
+  }
+  result <- tryReport("myReportFunction()", "")
+  expect_equal(result[["type"]], "warning")
+  expect_equal(result[["message"]], "2 warnings, first: Warning 1")
+  expect_equal(sapply(result[["result"]], conditionMessage), c("Warning 1", "Warning 2"))
+})
+
+test_that("tryReport returns validationError when report returns non-magpie object", {
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c())
+    }
+  )
+  myReportFunction <- function() return(42L)
+  result <- tryReport("myReportFunction()", "")
+  expect_equal(result[["type"]], "validationError")
+  expect_equal(result[["message"]], "ERROR - no magpie object")
+})
+
+test_that("tryReport returns validationError when report returns magpie with wrong years", {
   withr::local_dir(withr::local_tempdir())
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c("y2020", "y2030"))
+    }
+  )
+  myReportFunction <- function() return(new.magpie(c("AFR", "CPA", "GLO"), years = c("y2025"), fill = 1))
+  result <- tryReport("myReportFunction()", "")
+  expect_equal(result[["type"]], "validationError")
+  expect_equal(result[["message"]], "ERROR - wrong years")
+})
+
+test_that("tryReport validates the regions returned by a report function", {
 
   # regglo
   local_mocked_bindings(
@@ -35,6 +118,8 @@ test_that("tryReport validates the regions returned by a report function", {
 
 
   # Custom Mapping
+  withr::local_dir(withr::local_tempdir())
+
   tempMapping <- "RegionCode;NewRegionCode
 AFR;AFR
 CPA;CPA
@@ -55,4 +140,30 @@ CPA;REG1"
   result <- tryReport("myReportFunction()", "", level = "mymapping.csv")
   expect_equal(result[["type"]], "validationError")
   expect_equal(result[["message"]], "ERROR - wrong regions")
+})
+
+test_that("tryReport returns validationError when report returns magpie with names containing dots", {
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c())
+    }
+  )
+  myReportFunction <- function() return(new.magpie(c("AFR", "CPA", "GLO"), names = "name.with.dot", fill = 1))
+  result <- tryReport("myReportFunction()", "")
+  expect_equal(result[["type"]], "validationError")
+  expect_equal(result[["message"]], "ERROR - data names contain dots (.)")
+})
+
+test_that("tryReport returns success for valid magpie report", {
+  local_mocked_bindings(
+    readGDX = function(x, type) {
+      if (type == "i") return(c("AFR", "CPA"))
+      if (type == "t") return(c())
+    }
+  )
+  myReportFunction <- function() return(new.magpie(c("AFR", "CPA", "GLO")))
+  result <- tryReport("myReportFunction()", "")
+  expect_equal(result[["type"]], "success")
+  expect_true(is.magpie(result[["result"]]))
 })

--- a/tests/testthat/test-tryReport.R
+++ b/tests/testthat/test-tryReport.R
@@ -52,7 +52,7 @@ test_that("tryReport returns warning result when report returns a warning", {
   result <- tryReport("myReportFunction()", "")
   expect_equal(result[["type"]], "warning")
   expect_equal(result[["message"]], "2 warnings, first: Warning 1")
-  expect_equal(sapply(result[["result"]], conditionMessage), c("Warning 1", "Warning 2"))
+  expect_equal(sapply(result[["warnings"]], conditionMessage), c("Warning 1", "Warning 2"))
 })
 
 test_that("tryReport returns validationError when report returns non-magpie object", {


### PR DESCRIPTION
This PR changes the tryList/tryReport behavior in that they now properly collect warnings during report functions and a) list them in the full report log and b) rethrow them at the end.

This also adds corresponding tests.