### PR TITLE
Reconcile gross sub-components with the natural-origin secdforest correction

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '56861520'
+ValidationKey: '56895927'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 2.76.0
-date-released: '2026-05-29'
+version: 2.76.1
+date-released: '2026-06-03'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 2.76.0
-Date: 2026-05-29
+Version: 2.76.1
+Date: 2026-06-03
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/emisCO2.R
+++ b/R/emisCO2.R
@@ -680,6 +680,15 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
                 disturbanceLossAcEst = NULL,
                 recoveredForest      = recoveredForest)
             regrowthEmisSecdforest <- regrowthEmisSecdf_nonNat + regrowthEmisSecdf_nat
+
+            # Loss-side companion to the gain-side natural split: natural-cohort non-aging area
+            # flux valued at the vegc density gap, routed into emisDegrad below (follow-up to PR#135).
+            gapVegRegrow <- collapseNames(densities$secdforest[, , "vegc"]) -
+                            collapseNames(densityUncalibRaw[, getYears(area), "vegc"])
+            natFlux      <- collapseNames(naturalArea) -
+                            .acGrow(.tShift(collapseNames(naturalArea))) +
+                            collapseNames(recoveredForest)
+            structObjVeg <- dimSums(natFlux * gapVegRegrow, dim = "ac")
         } else {
             regrowthEmisSecdforest <- .regrowth(densityAg            = densityAg,
                                                 area                 = area,
@@ -689,6 +698,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
                                                 recoveredForest      = recoveredForest)
             regrowthEmisSecdf_nonNat <- NULL
             regrowthEmisSecdf_nat    <- NULL
+            structObjVeg             <- NULL
         }
 
         # --- Other land
@@ -776,7 +786,7 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
 
         regrowth <- dimSums(regrowth, dim = "ac")
 
-        return(regrowth)
+        return(list(regrowth = regrowth, structObjVeg = structObjVeg))
     }
 
     ###
@@ -796,7 +806,9 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
 
     # --- calculate individual emissions
     grossEmissions <- calculateGrossEmissions(areas = areas, densities = densities)
-    regrowth       <- calculateRegrowthEmissions(areas = areas, densities = densities)
+    regrowthOut    <- calculateRegrowthEmissions(areas = areas, densities = densities)
+    regrowth       <- regrowthOut$regrowth
+    structObjVeg   <- regrowthOut$structObjVeg
 
     ###
     # PREPARE OUTPUT OBJECT -------------------------------------------------------------------------------------------
@@ -814,6 +826,11 @@ emisCO2 <- function(gdx, file = NULL, level = "cell", unit = "gas",
     emisDegrad        <- grossEmissions$emisDegrad
     emisOtherLand     <- grossEmissions$emisOtherLand
     emisHarvest       <- grossEmissions$emisHarvest
+
+    # Reconcile the gross sub-components with the natural-origin-corrected emisArea (no-op pre-PR#876).
+    if (!is.null(structObjVeg)) {
+        emisDegrad[, , "secdforest.vegc"] <- emisDegrad[, , "secdforest.vegc"] + structObjVeg
+    }
 
     subcomponents <- emisRegrowth + emisDeforestation + emisDegrad + emisOtherLand + emisHarvest
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **2.76.0**
+R package **magpie4**, version **2.76.1**
 
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.76.0, <https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.76.1, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves and Pascal Sauer and Markus Bonsch and Singh Vartika and Patrick Rein},
   doi = {10.5281/zenodo.1158582},
-  date = {2026-05-29},
+  date = {2026-06-03},
   year = {2026},
   url = {https://github.com/pik-piam/magpie4},
-  note = {Version: 2.76.0},
+  note = {Version: 2.76.1},
 }
 ```

--- a/man/addGeometry.Rd
+++ b/man/addGeometry.Rd
@@ -29,11 +29,11 @@ attr(landUseEnriched, "crs")
 
 }
 \seealso{
-Other Spatial:
-\code{\link[=clusterOutputToTerraVector]{clusterOutputToTerraVector()}},
-\code{\link[=gdxAggregate]{gdxAggregate()}},
-\code{\link[=mappingToLongFormat]{mappingToLongFormat()}},
-\code{\link[=superAggregateX]{superAggregateX()}}
+Other Spatial: 
+\code{\link{clusterOutputToTerraVector}()},
+\code{\link{gdxAggregate}()},
+\code{\link{mappingToLongFormat}()},
+\code{\link{superAggregateX}()}
 }
 \author{
 Jan Philipp Dietrich, Pascal Sauer

--- a/man/addToDataChangelog.Rd
+++ b/man/addToDataChangelog.Rd
@@ -39,9 +39,9 @@ Invisibly, the written changelog as data.frame
 Prepend data from the given report to the changelog.
 }
 \seealso{
-Other Data Changelog:
-\code{\link[=changelogVariables]{changelogVariables()}},
-\code{\link[=changelogYears]{changelogYears()}}
+Other Data Changelog: 
+\code{\link{changelogVariables}()},
+\code{\link{changelogYears}()}
 }
 \author{
 Pascal Sauer

--- a/man/changelogVariables.Rd
+++ b/man/changelogVariables.Rd
@@ -10,9 +10,9 @@ changelogVariables()
 Returns a named vector of variables to put into the data changelog, see \code{\link{addToDataChangelog}}.
 }
 \seealso{
-Other Data Changelog:
-\code{\link[=addToDataChangelog]{addToDataChangelog()}},
-\code{\link[=changelogYears]{changelogYears()}}
+Other Data Changelog: 
+\code{\link{addToDataChangelog}()},
+\code{\link{changelogYears}()}
 }
 \author{
 Pascal Sauer

--- a/man/changelogYears.Rd
+++ b/man/changelogYears.Rd
@@ -10,9 +10,9 @@ changelogYears()
 Returns the years to put into the data changelog, see \code{\link{addToDataChangelog}}.
 }
 \seealso{
-Other Data Changelog:
-\code{\link[=addToDataChangelog]{addToDataChangelog()}},
-\code{\link[=changelogVariables]{changelogVariables()}}
+Other Data Changelog: 
+\code{\link{addToDataChangelog}()},
+\code{\link{changelogVariables}()}
 }
 \author{
 Pascal Sauer

--- a/man/clusterOutputToTerraVector.Rd
+++ b/man/clusterOutputToTerraVector.Rd
@@ -28,11 +28,11 @@ terra::writeVector(clusterPolygons, "cluster_resolution.shp")
 
 }
 \seealso{
-Other Spatial:
-\code{\link[=addGeometry]{addGeometry()}},
-\code{\link[=gdxAggregate]{gdxAggregate()}},
-\code{\link[=mappingToLongFormat]{mappingToLongFormat()}},
-\code{\link[=superAggregateX]{superAggregateX()}}
+Other Spatial: 
+\code{\link{addGeometry}()},
+\code{\link{gdxAggregate}()},
+\code{\link{mappingToLongFormat}()},
+\code{\link{superAggregateX}()}
 }
 \author{
 Pascal Führlich, Patrick v. Jeetze

--- a/man/expectVariablesPresent.Rd
+++ b/man/expectVariablesPresent.Rd
@@ -21,11 +21,11 @@ Checks whether a set of expected variable names is present in a
   are removed.
 }
 \seealso{
-Other Infrastructure:
-\code{\link[=metadata_comments]{metadata_comments()}},
-\code{\link[=out]{out()}},
-\code{\link[=tryList]{tryList()}},
-\code{\link[=tryReport]{tryReport()}}
+Other Infrastructure: 
+\code{\link{metadata_comments}()},
+\code{\link{out}()},
+\code{\link{tryList}()},
+\code{\link{tryReport}()}
 }
 \author{
 Patrick Rein

--- a/man/gdxAggregate.Rd
+++ b/man/gdxAggregate.Rd
@@ -40,11 +40,11 @@ gdp_glo <- gdxAggregate(gdx = gdx, x = gdp, weight = "population", to = "glo", a
 }
 }
 \seealso{
-Other Spatial:
-\code{\link[=addGeometry]{addGeometry()}},
-\code{\link[=clusterOutputToTerraVector]{clusterOutputToTerraVector()}},
-\code{\link[=mappingToLongFormat]{mappingToLongFormat()}},
-\code{\link[=superAggregateX]{superAggregateX()}}
+Other Spatial: 
+\code{\link{addGeometry}()},
+\code{\link{clusterOutputToTerraVector}()},
+\code{\link{mappingToLongFormat}()},
+\code{\link{superAggregateX}()}
 }
 \author{
 Benjamin Leon Bodirsky, Edna J. Molina Bacca, Florian Humpenoeder

--- a/man/mappingToLongFormat.Rd
+++ b/man/mappingToLongFormat.Rd
@@ -34,11 +34,11 @@ formulas that we could use in madrat functions. If the magpie4 aggregation logic
 is ever rewritten, this function may become obsolete.
 }
 \seealso{
-Other Spatial:
-\code{\link[=addGeometry]{addGeometry()}},
-\code{\link[=clusterOutputToTerraVector]{clusterOutputToTerraVector()}},
-\code{\link[=gdxAggregate]{gdxAggregate()}},
-\code{\link[=superAggregateX]{superAggregateX()}}
+Other Spatial: 
+\code{\link{addGeometry}()},
+\code{\link{clusterOutputToTerraVector}()},
+\code{\link{gdxAggregate}()},
+\code{\link{superAggregateX}()}
 }
 \author{
 Kristine Karstens, Patrick Rein

--- a/man/metadata_comments.Rd
+++ b/man/metadata_comments.Rd
@@ -31,11 +31,11 @@ set metadata comments to magpie4 objects
 
 }
 \seealso{
-Other Infrastructure:
-\code{\link[=expectVariablesPresent]{expectVariablesPresent()}},
-\code{\link[=out]{out()}},
-\code{\link[=tryList]{tryList()}},
-\code{\link[=tryReport]{tryReport()}}
+Other Infrastructure: 
+\code{\link{expectVariablesPresent}()},
+\code{\link{out}()},
+\code{\link{tryList}()},
+\code{\link{tryReport}()}
 }
 \author{
 Benjamin Bodirsky, Jannes Breier

--- a/man/out.Rd
+++ b/man/out.Rd
@@ -21,11 +21,11 @@ writes it to a file. Please use this function when you write own GDX output
 functions.
 }
 \seealso{
-Other Infrastructure:
-\code{\link[=expectVariablesPresent]{expectVariablesPresent()}},
-\code{\link[=metadata_comments]{metadata_comments()}},
-\code{\link[=tryList]{tryList()}},
-\code{\link[=tryReport]{tryReport()}}
+Other Infrastructure: 
+\code{\link{expectVariablesPresent}()},
+\code{\link{metadata_comments}()},
+\code{\link{tryList}()},
+\code{\link{tryReport}()}
 }
 \author{
 Jan Philipp Dietrich

--- a/man/superAggregateX.Rd
+++ b/man/superAggregateX.Rd
@@ -37,11 +37,11 @@ object.
 drop-in replacement for superAggregate based on toolAggregate
 }
 \seealso{
-Other Spatial:
-\code{\link[=addGeometry]{addGeometry()}},
-\code{\link[=clusterOutputToTerraVector]{clusterOutputToTerraVector()}},
-\code{\link[=gdxAggregate]{gdxAggregate()}},
-\code{\link[=mappingToLongFormat]{mappingToLongFormat()}}
+Other Spatial: 
+\code{\link{addGeometry}()},
+\code{\link{clusterOutputToTerraVector}()},
+\code{\link{gdxAggregate}()},
+\code{\link{mappingToLongFormat}()}
 }
 \author{
 Jan Philipp Dietrich

--- a/man/tryList.Rd
+++ b/man/tryList.Rd
@@ -23,11 +23,11 @@ a \code{\link{tryReport}} environment.
 \seealso{
 \code{\link{tryReport}}, \code{\link{reportResult}}
 
-Other Infrastructure:
-\code{\link[=expectVariablesPresent]{expectVariablesPresent()}},
-\code{\link[=metadata_comments]{metadata_comments()}},
-\code{\link[=out]{out()}},
-\code{\link[=tryReport]{tryReport()}}
+Other Infrastructure: 
+\code{\link{expectVariablesPresent}()},
+\code{\link{metadata_comments}()},
+\code{\link{out}()},
+\code{\link{tryReport}()}
 }
 \author{
 Jan Philipp Dietrich

--- a/man/tryReport.Rd
+++ b/man/tryReport.Rd
@@ -27,11 +27,11 @@ further processing in case of an error.
 \seealso{
 \code{\link{reportResult}}
 
-Other Infrastructure:
-\code{\link[=expectVariablesPresent]{expectVariablesPresent()}},
-\code{\link[=metadata_comments]{metadata_comments()}},
-\code{\link[=out]{out()}},
-\code{\link[=tryList]{tryList()}}
+Other Infrastructure: 
+\code{\link{expectVariablesPresent}()},
+\code{\link{metadata_comments}()},
+\code{\link{out}()},
+\code{\link{tryList}()}
 }
 \author{
 Jan Philipp Dietrich


### PR DESCRIPTION
Follow-up to #135 (which completed the net-emissions identity). The natural-origin secdforest correction in calculateMainEmissions subtracts the area effect of natRaw*gapVeg from the aggregate emisArea(secdforest.vegc) but leaves the gross loss sub-components (deforestation/harvest/degradation) valued at the calibrated density. emisArea - sum(sub-components) therefore retained a residual on secdforest.vegc (~0.2 Mt CO2/yr/cell, ~0.4 Mt net), tripping .validateCalculation's "land use sub-components" check.

Compute the natural-cohort loss-side correction in calculateRegrowthEmissions (mirroring the existing gain-side natural split):

  structObj = dimSums((naturalArea - acGrow(tShift(naturalArea)) + recoveredForest) * gapVeg, ac)

and route it into the secdforest.vegc degradation component so the reported gross decomposition reconciles with the natural-origin-corrected emisArea.

Verified on a post-#876 climate-change run: secdforest.vegc sub-components residual 0.20 -> 6.5e-9, net identity unchanged (1.9e-12), gross emissions >= 0. No-op for pre-#876 gdx files (graceful fallback).