### PR TITLE
Yield reporting rename

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '57901200'
+ValidationKey: '57912400'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '57754774'
+ValidationKey: '57901200'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
-version: 2.79.4
-date-released: '2026-08-06'
+version: 2.80.0
+date-released: '2026-08-14'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'magpie4: MAgPIE outputs R package for MAgPIE version 4.x'
 version: 2.80.0
-date-released: '2026-08-14'
+date-released: '2026-08-18'
 abstract: Common output routines for extracting results from the MAgPIE framework
   (versions 4.x).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
-Version: 2.79.4
-Date: 2026-08-06
+Version: 2.80.0
+Date: 2026-08-14
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: magpie4
 Title: MAgPIE outputs R package for MAgPIE version 4.x
 Version: 2.80.0
-Date: 2026-08-14
+Date: 2026-08-18
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),

--- a/R/YieldsCropCalib.R
+++ b/R/YieldsCropCalib.R
@@ -7,7 +7,8 @@
 #' @param file a file name the output should be written to using write.magpie
 #' @param level Level of regional aggregation
 #' @param tau if TRUE add effect of TAU to the yield
-#' @return A MAgPIE object containing values of potential yields after the calibration routines
+#' @return A MAgPIE object containing values of potential yields after the calibration routines.
+#' With \code{tau = TRUE} the result equals \code{vm_yld}.
 #' @author Edna Molina Bacca
 #' @importFrom magpiesets findset
 #' @importFrom magclass magpiesort

--- a/R/YieldsCropRaw.R
+++ b/R/YieldsCropRaw.R
@@ -1,12 +1,13 @@
 #' @title YieldsCropRaw
-#' @description Reads potential yields after calibration
+#' @description Reads uncalibrated potential yields, i.e. before the calibration routines
 #'
 #' @export
 #'
 #' @param gdx GDX file
 #' @param file a file name the output should be written to using write.magpie
 #' @param level Level of regional aggregation
-#' @return A MAgPIE object containing values of potential yields after the calibration routines
+#' @return A MAgPIE object containing values of potential yields as they come from the crop
+#' model, before the calibration routines are applied.
 #' @author Edna Molina Bacca
 #' @importFrom magclass magpiesort
 #'

--- a/R/reportYields.R
+++ b/R/reportYields.R
@@ -66,7 +66,10 @@ reportYields <- function(gdx, detail = FALSE, physical = TRUE, level = "regglo")
     prod <- reporthelper(x = prod, dim = 3.1, level_zero_name = indicatorName,
                          detail = detail)
 
-    area <- croparea(gdx, level = level, products = readGDX(gdx, "kcr"),
+    # The multicropping index is regional, so the harvested-area path has to build its area at
+    # region level and aggregate afterwards - `level = "glo"` has no regions to index.
+    areaLevel <- if (physical) level else "reg"
+    area <- croparea(gdx, level = areaLevel, products = readGDX(gdx, "kcr"),
                      product_aggr = FALSE, water_aggr = watAgg)
     area <- reporthelper(x = area, dim = 3.1, level_zero_name = indicatorName,
                          detail = detail)
@@ -77,12 +80,9 @@ reportYields <- function(gdx, detail = FALSE, physical = TRUE, level = "regglo")
                                format = "first_found",
                                level = "reg",
                                types = "parameters")[, getYears(area), ]
-      # Correct regions
-      areaREG <- area[getItems(multicropping, dim = 1.1), , ]
-      # Transform crop area (physical area) into harvested area
-      areaREG <- areaREG * multicropping
-      # Global sum and regions
-      area <- gdxAggregate(gdx, areaREG, to = level)
+      # Transform crop area (physical area) into harvested area, then aggregate
+      area <- area[getItems(multicropping, dim = 1.1), , ] * multicropping
+      area <- gdxAggregate(gdx, area, to = level)
     }
 
     out <- ifelse(prod > 1e-10, prod / area, NA)

--- a/R/reportYields.R
+++ b/R/reportYields.R
@@ -22,24 +22,30 @@
 #' so the ratio between the two families is not a clean yield gap.
 #'
 #' @section Yield by physical area variables:
+#' Reported when `physical = TRUE` (the default). 22 variables at `detail = FALSE`, 76 at
+#' `detail = TRUE`. The stem itself is not reported, and no name carries a `+` summation
+#' marker - unlike `reportYieldsCropRaw` and `reportYieldsCropCalib`, which do emit them.
+#'
 #' Name | Unit | Meta
 #' ---|---|---
-#' Productivity\|Yields\|Yield by physical area | t DM/ha | Crop yields calculated as production divided by physical cropland area (fallow excluded)
-#' Productivity\|Yields\|Yield by physical area\|+\|Crops | t DM/ha | Yield of all crops
-#' Productivity\|Yields\|Yield by physical area\|Crops\|+\|Cereals | t DM/ha | Yield of cereals (maize, rice, temperate cereals and tropical cereals)
-#' Productivity\|Yields\|Yield by physical area\|Crops\|+\|Oil crops | t DM/ha | Yield of oil crops (cotton seed, groundnuts, oilpalms, other oil crops, soybean, sunflower)
-#' Productivity\|Yields\|Yield by physical area\|Crops\|+\|Sugar crops | t DM/ha | Yield of sugar crops (sugar beet, sugar cane)
-#' Productivity\|Yields\|Yield by physical area\|Crops\|+\|Other crops | t DM/ha | Yield of other crops (fruits, vegetables, nuts, potatoes, pulses, tropical roots)
-#' Productivity\|Yields\|Yield by physical area\|+\|Pasture | t DM/ha | Yield of pasture biomass
-#' Productivity\|Yields\|Yield by physical area\|++\|Irrigated | t DM/ha | Yield on irrigated cropland
-#' Productivity\|Yields\|Yield by physical area\|++\|Rainfed | t DM/ha | Yield on rainfed cropland
+#' Productivity\|Yields\|Yield by physical area\|Crops | t DM/ha | Yield of all crops
+#' Productivity\|Yields\|Yield by physical area\|Crops\|Cereals | t DM/ha | Cereals (maize, rice, temperate cereals, tropical cereals)
+#' Productivity\|Yields\|Yield by physical area\|Crops\|Oil crops | t DM/ha | Oil crops (cotton seed, groundnuts, oilpalms, other oil crops, soybean, sunflower)
+#' Productivity\|Yields\|Yield by physical area\|Crops\|Sugar crops | t DM/ha | Sugar crops (sugar beet, sugar cane)
+#' Productivity\|Yields\|Yield by physical area\|Crops\|Other crops | t DM/ha | Other crops (fruits, vegetables, nuts, potatoes, pulses, tropical roots)
+#' Productivity\|Yields\|Yield by physical area\|Bioenergy crops | t DM/ha | Second-generation bioenergy crops
+#' Productivity\|Yields\|Yield by physical area\|Forage | t DM/ha | Forage crops
+#' Productivity\|Yields\|Yield by physical area\|Pasture | t DM/ha | Pasture biomass; no water split
+#'
+#' Every entry except Pasture is also reported split by water supply, as a lowercase leaf
+#' (e.g. \|Crops\|irrigated) rather than a top-level branch. With `detail = TRUE` each group
+#' additionally gains its individual crops on the same pattern.
 #'
 #' @section Yield by harvested area variables:
-#' Name | Unit | Meta
-#' ---|---|---
-#' Productivity\|Yields\|Yield by harvested area | t DM/ha | Crop yields calculated as production divided by harvested cropland area (physical area scaled by the exogenous multicropping index)
-#' Productivity\|Yields\|Yield by harvested area\|+\|Crops | t DM/ha | Yield by harvested area of all crops
-#' Productivity\|Yields\|Yield by harvested area\|Crops\|+\|Cereals | t DM/ha | Yield by harvested area of cereals
+#' Reported when `physical = FALSE`. Same tree and counts, under the stem
+#' Productivity\|Yields\|Yield by harvested area. Harvested area is physical area scaled by
+#' the regional multicropping index `f18_multicropping`, so these yields differ from those
+#' above by cropping intensity.
 #' @md
 reportYields <- function(gdx, detail = FALSE, physical = TRUE, level = "regglo") {
 

--- a/R/reportYields.R
+++ b/R/reportYields.R
@@ -9,7 +9,7 @@
 #' @param detail   if detail=FALSE, the subcategories of groups are not reported (e.g. "soybean" within "oilcrops")
 #' @param physical if true (default) physical area (croparea) used for yield calculation;
 #'                 if false harvested area used for yield calculation
-#' @return yield as MAgPIE object (Mt DM/ha)
+#' @return yield as MAgPIE object (t DM/ha)
 #' @importFrom magpiesets reporthelper
 #' @author Florian Humpenoeder, Xiaoxi Wang, Kristine Karstens, Abhijeet Mishra, Felicitas Beier
 #' @examples
@@ -17,32 +17,36 @@
 #' x <- reportYields(gdx)
 #' }
 #'
-#' @section Yield variables:
+#' @details Realized yields, weighted by the endogenous cropping pattern. The
+#' `Productivity|Yields|Input data|*` variables hold the 1995 cropping pattern fixed instead,
+#' so the ratio between the two families is not a clean yield gap.
+#'
+#' @section Yield by physical area variables:
 #' Name | Unit | Meta
 #' ---|---|---
-#' Productivity\|Yield | t DM/ha | Crop yields calculated as production divided by physical cropland area
-#' Productivity\|Yield\|+\|Crops | t DM/ha | Yield of all crops
-#' Productivity\|Yield\|Crops\|+\|Cereals | t DM/ha | Yield of cereals (maize, rice, temperate cereals and tropical cereals)
-#' Productivity\|Yield\|Crops\|+\|Oil crops | t DM/ha | Yield of oil crops (cotton seed, groundnuts, oilpalms, other oil crops, soybean, sunflower)
-#' Productivity\|Yield\|Crops\|+\|Sugar crops | t DM/ha | Yield of sugar crops (sugar beet, sugar cane)
-#' Productivity\|Yield\|Crops\|+\|Other crops | t DM/ha | Yield of other crops (fruits, vegetables, nuts, potatoes, pulses, tropical roots)
-#' Productivity\|Yield\|+\|Pasture | t DM/ha | Yield of pasture biomass
-#' Productivity\|Yield\|++\|Irrigated | t DM/ha | Yield on irrigated cropland
-#' Productivity\|Yield\|++\|Rainfed | t DM/ha | Yield on rainfed cropland
+#' Productivity\|Yields\|Yield by physical area | t DM/ha | Crop yields calculated as production divided by physical cropland area (fallow excluded)
+#' Productivity\|Yields\|Yield by physical area\|+\|Crops | t DM/ha | Yield of all crops
+#' Productivity\|Yields\|Yield by physical area\|Crops\|+\|Cereals | t DM/ha | Yield of cereals (maize, rice, temperate cereals and tropical cereals)
+#' Productivity\|Yields\|Yield by physical area\|Crops\|+\|Oil crops | t DM/ha | Yield of oil crops (cotton seed, groundnuts, oilpalms, other oil crops, soybean, sunflower)
+#' Productivity\|Yields\|Yield by physical area\|Crops\|+\|Sugar crops | t DM/ha | Yield of sugar crops (sugar beet, sugar cane)
+#' Productivity\|Yields\|Yield by physical area\|Crops\|+\|Other crops | t DM/ha | Yield of other crops (fruits, vegetables, nuts, potatoes, pulses, tropical roots)
+#' Productivity\|Yields\|Yield by physical area\|+\|Pasture | t DM/ha | Yield of pasture biomass
+#' Productivity\|Yields\|Yield by physical area\|++\|Irrigated | t DM/ha | Yield on irrigated cropland
+#' Productivity\|Yields\|Yield by physical area\|++\|Rainfed | t DM/ha | Yield on rainfed cropland
 #'
 #' @section Yield by harvested area variables:
 #' Name | Unit | Meta
 #' ---|---|---
-#' Productivity\|Yield by harvested area | t DM/ha | Crop yields calculated as production divided by harvested cropland area
-#' Productivity\|Yield by harvested area\|+\|Crops | t DM/ha | Yield by harvested area of all crops
-#' Productivity\|Yield by harvested area\|Crops\|+\|Cereals | t DM/ha | Yield by harvested area of cereals
+#' Productivity\|Yields\|Yield by harvested area | t DM/ha | Crop yields calculated as production divided by harvested cropland area (physical area scaled by the exogenous multicropping index)
+#' Productivity\|Yields\|Yield by harvested area\|+\|Crops | t DM/ha | Yield by harvested area of all crops
+#' Productivity\|Yields\|Yield by harvested area\|Crops\|+\|Cereals | t DM/ha | Yield by harvested area of cereals
 #' @md
 reportYields <- function(gdx, detail = FALSE, physical = TRUE, level = "regglo") {
 
   if (physical) {
-    indicatorName <- "Productivity|Yield"
+    indicatorName <- "Productivity|Yields|Yield by physical area"
   } else {
-    indicatorName <- "Productivity|Yield by harvested area"
+    indicatorName <- "Productivity|Yields|Yield by harvested area"
   }
 
   if (!(level %in% c("reg", "regglo", "glo") || isCustomAggregation(level))) {

--- a/R/reportYieldsCropCalib.R
+++ b/R/reportYieldsCropCalib.R
@@ -7,19 +7,23 @@
 #' @param gdx GDX file
 #' @param level aggregation level of returned data ("regglo" by default)
 #' @param detail if detail=FALSE, the subcategories of groups are not reported (e.g. "soybean" within "oilcrops")
-#' @return yield as MAgPIE object (Mt DM/ha)
+#' @return yield as MAgPIE object (t DM/ha)
 #' @author Edna J. Molina Bacca
 #' @examples
 #' \dontrun{
 #' x <- reportYieldsCropCalib(gdx)
 #' }
 #'
-#' @section Calibrated yield variables:
+#' @details `Calibrated` is the crop-model input after management calibration but before
+#' technological change; `Calibrated|Including technological change` additionally applies tau
+#' and equals `vm_yld`. Both are weighted with the 1995 cropping pattern held fixed.
+#'
+#' @section Calibrated input-data yield variables:
 #' Name | Unit | Meta
 #' ---|---|---
-#' Productivity\|Yield (after calibration) | t DM/ha | Potential crop yields after calibration
-#' Productivity\|Yield (after calibration)\|+\|Cereals | t DM/ha | Calibrated cereal yields
-#' Productivity\|Yield (including tau) | t DM/ha | Potential yields including tau factor
+#' Productivity\|Yields\|Input data\|Calibrated | t DM/ha | Potential crop yields after calibration, before technological change
+#' Productivity\|Yields\|Input data\|Calibrated\|+\|Cereals | t DM/ha | Calibrated cereal yields
+#' Productivity\|Yields\|Input data\|Calibrated\|Including technological change | t DM/ha | Calibrated potential yields with the tau factor applied (equals vm_yld)
 #' @md
 
 #'
@@ -67,13 +71,13 @@ reportYieldsCropCalib <- function(gdx, detail = FALSE, level = "regglo") {
   }
 
   x <- mbind(yieldWaterAgg(gdx, water_aggr = TRUE, sum_sep = "+",
-                           tau = FALSE, level_zero_name = "Productivity|Yield (after calibration)", detail = detail),
+                           tau = FALSE, level_zero_name = "Productivity|Yields|Input data|Calibrated", detail = detail),
              yieldWaterAgg(gdx, water_aggr = FALSE, sum_sep = NULL,
-                           tau = FALSE, level_zero_name = "Productivity|Yield (after calibration)", detail = detail),
+                           tau = FALSE, level_zero_name = "Productivity|Yields|Input data|Calibrated", detail = detail),
              yieldWaterAgg(gdx, water_aggr = TRUE, sum_sep = "+",
-                           tau = TRUE, level_zero_name = "Productivity|Yield (including tau)", detail = detail),
+                           tau = TRUE, level_zero_name = "Productivity|Yields|Input data|Calibrated|Including technological change", detail = detail),
              yieldWaterAgg(gdx, water_aggr = FALSE, sum_sep = NULL,
-                           tau = TRUE, level_zero_name = "Productivity|Yield (including tau)", detail = detail))
+                           tau = TRUE, level_zero_name = "Productivity|Yields|Input data|Calibrated|Including technological change", detail = detail))
   x[!is.finite(x)] <- 0
 
   return(x)

--- a/R/reportYieldsCropRaw.R
+++ b/R/reportYieldsCropRaw.R
@@ -7,18 +7,21 @@
 #' @param gdx GDX file
 #' @param level aggregation level of returned data ("regglo" by default)
 #' @param detail if detail=FALSE, the subcategories of groups are not reported (e.g. "soybean" within "oilcrops")
-#' @return yield as MAgPIE object (Mt DM/ha)
+#' @return yield as MAgPIE object (t DM/ha)
 #' @author Edna J. Molina Bacca
 #' @examples
 #' \dontrun{
 #' x <- reportYieldsCropRaw(gdx)
 #' }
 #'
-#' @section Raw yield variables:
+#' @details Uncalibrated potential yields as they come from the crop model, before management
+#' calibration and technological change. Weighted with the 1995 cropping pattern held fixed.
+#'
+#' @section Uncalibrated input-data yield variables:
 #' Name | Unit | Meta
 #' ---|---|---
-#' Productivity\|Yield (before calibration) | t DM/ha | Potential crop yields before calibration
-#' Productivity\|Yield (before calibration)\|+\|Cereals | t DM/ha | Uncalibrated cereal yields
+#' Productivity\|Yields\|Input data\|Uncalibrated | t DM/ha | Potential crop yields before calibration
+#' Productivity\|Yields\|Input data\|Uncalibrated\|+\|Cereals | t DM/ha | Uncalibrated cereal yields
 #' @md
 
 #'
@@ -66,9 +69,9 @@ reportYieldsCropRaw <- function(gdx, detail = FALSE, level = "regglo") {
   }
 
   x <- mbind(yieldWaterAgg(gdx, water_aggr = TRUE, sum_sep = "+",
-                           level_zero_name = "Productivity|Yield (before calibration)", detail = detail),
+                           level_zero_name = "Productivity|Yields|Input data|Uncalibrated", detail = detail),
              yieldWaterAgg(gdx, water_aggr = FALSE, sum_sep = NULL,
-                           level_zero_name = "Productivity|Yield (before calibration)", detail = detail))
+                           level_zero_name = "Productivity|Yields|Input data|Uncalibrated", detail = detail))
   x[!is.finite(x)] <- 0
 
   return(x)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAgPIE outputs R package for MAgPIE version 4.x
 
-R package **magpie4**, version **2.79.4**
+R package **magpie4**, version **2.80.0**
 
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158582.svg)](https://doi.org/10.5281/zenodo.1158582) [![R build status](https://github.com/pik-piam/magpie4/workflows/check/badge.svg)](https://github.com/pik-piam/magpie4/actions) [![codecov](https://codecov.io/gh/pik-piam/magpie4/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magpie4) [![r-universe](https://pik-piam.r-universe.dev/badges/magpie4)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **magpie4** in publications use:
 
-Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.79.4, <https://github.com/pik-piam/magpie4>.
+Bodirsky B, Humpenoeder F, Dietrich J, Stevanovic M, Weindl I, Karstens K, Wang X, Mishra A, Beier F, Breier J, Yalew A, Chen D, Biewald A, Wirth S, von Jeetze P, Leip D, Crawford M, Alves M, Sauer P, Bonsch M, Vartika S, Rein P (2026). "magpie4: MAgPIE outputs R package for MAgPIE version 4.x." doi:10.5281/zenodo.1158582 <https://doi.org/10.5281/zenodo.1158582>, Version: 2.80.0, <https://github.com/pik-piam/magpie4>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves and Pascal Sauer and Markus Bonsch and Singh Vartika and Patrick Rein},
   doi = {10.5281/zenodo.1158582},
-  date = {2026-08-06},
+  date = {2026-08-14},
   year = {2026},
   url = {https://github.com/pik-piam/magpie4},
-  note = {Version: 2.79.4},
+  note = {Version: 2.80.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {magpie4: MAgPIE outputs R package for MAgPIE version 4.x},
   author = {Benjamin Leon Bodirsky and Florian Humpenoeder and Jan Philipp Dietrich and Miodrag Stevanovic and Isabelle Weindl and Kristine Karstens and Xiaoxi Wang and Abhijeet Mishra and Felicitas Beier and Jannes Breier and Amsalu Woldie Yalew and David Chen and Anne Biewald and Stephen Wirth and Patrick {von Jeetze} and Debbora Leip and Michael Crawford and Marcos Alves and Pascal Sauer and Markus Bonsch and Singh Vartika and Patrick Rein},
   doi = {10.5281/zenodo.1158582},
-  date = {2026-08-14},
+  date = {2026-08-18},
   year = {2026},
   url = {https://github.com/pik-piam/magpie4},
   note = {Version: 2.80.0},

--- a/inst/extdata/variablemappingBEST.csv
+++ b/inst/extdata/variablemappingBEST.csv
@@ -44,22 +44,22 @@ Resources|Land Cover|Forest|+|Managed Forest (million ha);Land Cover|Forest|Mana
 Resources|Land Cover|Forest|+|Natural Forest (million ha);Land Cover|Forest|Natural Forest (million ha);NULL;1
 Resources|Land Cover|+|Other Land (million ha);Land Cover|Other Land (million ha);NULL;1
 Resources|Land Cover|+|Urban Area (million ha);Land Cover|Built-up Area (million ha);NULL;1
-Productivity|Yield|+|Crops (t DM/ha);Yield|Crops (t DM/ha/yr);NULL;1
-Productivity|Yield|Crops|rainfed (t DM/ha);Yield|Crops|rainfed (t DM/ha/yr);NULL;1
-Productivity|Yield|Crops|irrigated (t DM/ha);Yield|Crops|irrigated (t DM/ha/yr);NULL;1
-Productivity|Yield|Crops|+|Cereals (t DM/ha);Yield|Crops|Cereal (t DM/ha/yr);NULL;1
-Productivity|Yield|Crops|+|Oil crops (t DM/ha);Yield|Crops|Oilcrops (t DM/ha/yr);NULL;1
-Productivity|Yield|Crops|+|Sugar crops (t DM/ha);Yield|Crops|Sugarcrops (t DM/ha/yr);NULL;1
-Productivity|Yield|Crops|+|Other crops (t DM/ha);Yield|Crops|Other crops (t DM/ha/yr);NULL;1
-Productivity|Yield|+|Bioenergy crops (t DM/ha);Yield|Bioenergy crops (t DM/ha/yr);NULL;1
-Productivity|Yield|Bioenergy crops|rainfed (t DM/ha);Yield|Bioenergy crops|rainfed (t DM/ha);NULL;1
-Productivity|Yield|Bioenergy crops|irrigated (t DM/ha);Yield|Bioenergy crops|irrigated (t DM/ha);NULL;1
-Productivity|Yield|Bioenergy crops|+|Short rotation grasses (t DM/ha);Yield|Bioenergy crops|Short rotation grasses (t DM/ha/yr);NULL;1
-Productivity|Yield|Bioenergy crops|Short rotation grasses|rainfed (t DM/ha);Yield|Bioenergy crops|Short rotation grasses|rainfed (t DM/ha/yr);NULL;1
-Productivity|Yield|Bioenergy crops|Short rotation grasses|irrigated (t DM/ha);Yield|Bioenergy crops|Short rotation grasses|irrigated (t DM/ha/yr);NULL;1
-Productivity|Yield|Bioenergy crops|+|Short rotation trees (t DM/ha);Yield|Bioenergy crops|Short rotation trees (t DM/ha/yr);NULL;1
-Productivity|Yield|Bioenergy crops|Short rotation trees|rainfed (t DM/ha);Yield|Bioenergy crops|Short rotation trees|rainfed (t DM/ha/yr);NULL;1
-Productivity|Yield|Bioenergy crops|Short rotation trees|irrigated (t DM/ha);Yield|Bioenergy crops|Short rotation trees|irrigated (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|+|Crops (t DM/ha);Yield|Crops (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Crops|rainfed (t DM/ha);Yield|Crops|rainfed (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Crops|irrigated (t DM/ha);Yield|Crops|irrigated (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Crops|+|Cereals (t DM/ha);Yield|Crops|Cereal (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Crops|+|Oil crops (t DM/ha);Yield|Crops|Oilcrops (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Crops|+|Sugar crops (t DM/ha);Yield|Crops|Sugarcrops (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Crops|+|Other crops (t DM/ha);Yield|Crops|Other crops (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|+|Bioenergy crops (t DM/ha);Yield|Bioenergy crops (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Bioenergy crops|rainfed (t DM/ha);Yield|Bioenergy crops|rainfed (t DM/ha);NULL;1
+Productivity|Yields|Yield by physical area|Bioenergy crops|irrigated (t DM/ha);Yield|Bioenergy crops|irrigated (t DM/ha);NULL;1
+Productivity|Yields|Yield by physical area|Bioenergy crops|+|Short rotation grasses (t DM/ha);Yield|Bioenergy crops|Short rotation grasses (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Bioenergy crops|Short rotation grasses|rainfed (t DM/ha);Yield|Bioenergy crops|Short rotation grasses|rainfed (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Bioenergy crops|Short rotation grasses|irrigated (t DM/ha);Yield|Bioenergy crops|Short rotation grasses|irrigated (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Bioenergy crops|+|Short rotation trees (t DM/ha);Yield|Bioenergy crops|Short rotation trees (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Bioenergy crops|Short rotation trees|rainfed (t DM/ha);Yield|Bioenergy crops|Short rotation trees|rainfed (t DM/ha/yr);NULL;1
+Productivity|Yields|Yield by physical area|Bioenergy crops|Short rotation trees|irrigated (t DM/ha);Yield|Bioenergy crops|Short rotation trees|irrigated (t DM/ha/yr);NULL;1
 Productivity|Landuse Intensity Indicator Tau (Index);Landuse Intensity Indicator Tau (Index);NULL;1
 Productivity|Yield-increasing technological change (%/yr);Yield-increasing technological change (%/yr);NULL;1
 Demand|Agricultural Supply Chain Loss|+|Crops (Mt DM/yr);Agricultural Demand (million t DM/yr);NULL;1

--- a/man/YieldsCropCalib.Rd
+++ b/man/YieldsCropCalib.Rd
@@ -16,7 +16,8 @@ YieldsCropCalib(gdx, file = NULL, level = "cell", tau = FALSE)
 \item{tau}{if TRUE add effect of TAU to the yield}
 }
 \value{
-A MAgPIE object containing values of potential yields after the calibration routines
+A MAgPIE object containing values of potential yields after the calibration routines.
+With \code{tau = TRUE} the result equals \code{vm_yld}.
 }
 \description{
 Reads potential yields after calibration

--- a/man/YieldsCropRaw.Rd
+++ b/man/YieldsCropRaw.Rd
@@ -14,10 +14,11 @@ YieldsCropRaw(gdx, file = NULL, level = "cell")
 \item{level}{Level of regional aggregation}
 }
 \value{
-A MAgPIE object containing values of potential yields after the calibration routines
+A MAgPIE object containing values of potential yields as they come from the crop
+model, before the calibration routines are applied.
 }
 \description{
-Reads potential yields after calibration
+Reads uncalibrated potential yields, i.e. before the calibration routines
 }
 \examples{
 \dontrun{

--- a/man/reportYields.Rd
+++ b/man/reportYields.Rd
@@ -28,27 +28,33 @@ Realized yields, weighted by the endogenous cropping pattern. The
 so the ratio between the two families is not a clean yield gap.
 }
 \section{Yield by physical area variables}{
-\tabular{lll}{
+
+Reported when \code{physical = TRUE} (the default). 22 variables at \code{detail = FALSE}, 76 at
+\code{detail = TRUE}. The stem itself is not reported, and no name carries a \code{+} summation
+marker - unlike \code{reportYieldsCropRaw} and \code{reportYieldsCropCalib}, which do emit them.\tabular{lll}{
    Name \tab Unit \tab Meta \cr
-   Productivity|Yields|Yield by physical area \tab t DM/ha \tab Crop yields calculated as production divided by physical cropland area (fallow excluded) \cr
-   Productivity|Yields|Yield by physical area|+|Crops \tab t DM/ha \tab Yield of all crops \cr
-   Productivity|Yields|Yield by physical area|Crops|+|Cereals \tab t DM/ha \tab Yield of cereals (maize, rice, temperate cereals and tropical cereals) \cr
-   Productivity|Yields|Yield by physical area|Crops|+|Oil crops \tab t DM/ha \tab Yield of oil crops (cotton seed, groundnuts, oilpalms, other oil crops, soybean, sunflower) \cr
-   Productivity|Yields|Yield by physical area|Crops|+|Sugar crops \tab t DM/ha \tab Yield of sugar crops (sugar beet, sugar cane) \cr
-   Productivity|Yields|Yield by physical area|Crops|+|Other crops \tab t DM/ha \tab Yield of other crops (fruits, vegetables, nuts, potatoes, pulses, tropical roots) \cr
-   Productivity|Yields|Yield by physical area|+|Pasture \tab t DM/ha \tab Yield of pasture biomass \cr
-   Productivity|Yields|Yield by physical area|++|Irrigated \tab t DM/ha \tab Yield on irrigated cropland \cr
-   Productivity|Yields|Yield by physical area|++|Rainfed \tab t DM/ha \tab Yield on rainfed cropland \cr
+   Productivity|Yields|Yield by physical area|Crops \tab t DM/ha \tab Yield of all crops \cr
+   Productivity|Yields|Yield by physical area|Crops|Cereals \tab t DM/ha \tab Cereals (maize, rice, temperate cereals, tropical cereals) \cr
+   Productivity|Yields|Yield by physical area|Crops|Oil crops \tab t DM/ha \tab Oil crops (cotton seed, groundnuts, oilpalms, other oil crops, soybean, sunflower) \cr
+   Productivity|Yields|Yield by physical area|Crops|Sugar crops \tab t DM/ha \tab Sugar crops (sugar beet, sugar cane) \cr
+   Productivity|Yields|Yield by physical area|Crops|Other crops \tab t DM/ha \tab Other crops (fruits, vegetables, nuts, potatoes, pulses, tropical roots) \cr
+   Productivity|Yields|Yield by physical area|Bioenergy crops \tab t DM/ha \tab Second-generation bioenergy crops \cr
+   Productivity|Yields|Yield by physical area|Forage \tab t DM/ha \tab Forage crops \cr
+   Productivity|Yields|Yield by physical area|Pasture \tab t DM/ha \tab Pasture biomass; no water split \cr
 }
+
+
+Every entry except Pasture is also reported split by water supply, as a lowercase leaf
+(e.g. \|Crops\|irrigated) rather than a top-level branch. With \code{detail = TRUE} each group
+additionally gains its individual crops on the same pattern.
 }
 
 \section{Yield by harvested area variables}{
-\tabular{lll}{
-   Name \tab Unit \tab Meta \cr
-   Productivity|Yields|Yield by harvested area \tab t DM/ha \tab Crop yields calculated as production divided by harvested cropland area (physical area scaled by the exogenous multicropping index) \cr
-   Productivity|Yields|Yield by harvested area|+|Crops \tab t DM/ha \tab Yield by harvested area of all crops \cr
-   Productivity|Yields|Yield by harvested area|Crops|+|Cereals \tab t DM/ha \tab Yield by harvested area of cereals \cr
-}
+
+Reported when \code{physical = FALSE}. Same tree and counts, under the stem
+Productivity\|Yields\|Yield by harvested area. Harvested area is physical area scaled by
+the regional multicropping index \code{f18_multicropping}, so these yields differ from those
+above by cropping intensity.
 }
 
 \examples{

--- a/man/reportYields.Rd
+++ b/man/reportYields.Rd
@@ -17,32 +17,37 @@ if false harvested area used for yield calculation}
 \item{level}{aggregation level of returned data ("regglo" by default)}
 }
 \value{
-yield as MAgPIE object (Mt DM/ha)
+yield as MAgPIE object (t DM/ha)
 }
 \description{
 reports yields
 }
-\section{Yield variables}{
+\details{
+Realized yields, weighted by the endogenous cropping pattern. The
+\verb{Productivity|Yields|Input data|*} variables hold the 1995 cropping pattern fixed instead,
+so the ratio between the two families is not a clean yield gap.
+}
+\section{Yield by physical area variables}{
 \tabular{lll}{
    Name \tab Unit \tab Meta \cr
-   Productivity|Yield \tab t DM/ha \tab Crop yields calculated as production divided by physical cropland area \cr
-   Productivity|Yield|+|Crops \tab t DM/ha \tab Yield of all crops \cr
-   Productivity|Yield|Crops|+|Cereals \tab t DM/ha \tab Yield of cereals (maize, rice, temperate cereals and tropical cereals) \cr
-   Productivity|Yield|Crops|+|Oil crops \tab t DM/ha \tab Yield of oil crops (cotton seed, groundnuts, oilpalms, other oil crops, soybean, sunflower) \cr
-   Productivity|Yield|Crops|+|Sugar crops \tab t DM/ha \tab Yield of sugar crops (sugar beet, sugar cane) \cr
-   Productivity|Yield|Crops|+|Other crops \tab t DM/ha \tab Yield of other crops (fruits, vegetables, nuts, potatoes, pulses, tropical roots) \cr
-   Productivity|Yield|+|Pasture \tab t DM/ha \tab Yield of pasture biomass \cr
-   Productivity|Yield|++|Irrigated \tab t DM/ha \tab Yield on irrigated cropland \cr
-   Productivity|Yield|++|Rainfed \tab t DM/ha \tab Yield on rainfed cropland \cr
+   Productivity|Yields|Yield by physical area \tab t DM/ha \tab Crop yields calculated as production divided by physical cropland area (fallow excluded) \cr
+   Productivity|Yields|Yield by physical area|+|Crops \tab t DM/ha \tab Yield of all crops \cr
+   Productivity|Yields|Yield by physical area|Crops|+|Cereals \tab t DM/ha \tab Yield of cereals (maize, rice, temperate cereals and tropical cereals) \cr
+   Productivity|Yields|Yield by physical area|Crops|+|Oil crops \tab t DM/ha \tab Yield of oil crops (cotton seed, groundnuts, oilpalms, other oil crops, soybean, sunflower) \cr
+   Productivity|Yields|Yield by physical area|Crops|+|Sugar crops \tab t DM/ha \tab Yield of sugar crops (sugar beet, sugar cane) \cr
+   Productivity|Yields|Yield by physical area|Crops|+|Other crops \tab t DM/ha \tab Yield of other crops (fruits, vegetables, nuts, potatoes, pulses, tropical roots) \cr
+   Productivity|Yields|Yield by physical area|+|Pasture \tab t DM/ha \tab Yield of pasture biomass \cr
+   Productivity|Yields|Yield by physical area|++|Irrigated \tab t DM/ha \tab Yield on irrigated cropland \cr
+   Productivity|Yields|Yield by physical area|++|Rainfed \tab t DM/ha \tab Yield on rainfed cropland \cr
 }
 }
 
 \section{Yield by harvested area variables}{
 \tabular{lll}{
    Name \tab Unit \tab Meta \cr
-   Productivity|Yield by harvested area \tab t DM/ha \tab Crop yields calculated as production divided by harvested cropland area \cr
-   Productivity|Yield by harvested area|+|Crops \tab t DM/ha \tab Yield by harvested area of all crops \cr
-   Productivity|Yield by harvested area|Crops|+|Cereals \tab t DM/ha \tab Yield by harvested area of cereals \cr
+   Productivity|Yields|Yield by harvested area \tab t DM/ha \tab Crop yields calculated as production divided by harvested cropland area (physical area scaled by the exogenous multicropping index) \cr
+   Productivity|Yields|Yield by harvested area|+|Crops \tab t DM/ha \tab Yield by harvested area of all crops \cr
+   Productivity|Yields|Yield by harvested area|Crops|+|Cereals \tab t DM/ha \tab Yield by harvested area of cereals \cr
 }
 }
 

--- a/man/reportYieldsCropCalib.Rd
+++ b/man/reportYieldsCropCalib.Rd
@@ -14,17 +14,22 @@ reportYieldsCropCalib(gdx, detail = FALSE, level = "regglo")
 \item{level}{aggregation level of returned data ("regglo" by default)}
 }
 \value{
-yield as MAgPIE object (Mt DM/ha)
+yield as MAgPIE object (t DM/ha)
 }
 \description{
 reports potential yields after calibration
 }
-\section{Calibrated yield variables}{
+\details{
+\code{Calibrated} is the crop-model input after management calibration but before
+technological change; \verb{Calibrated|Including technological change} additionally applies tau
+and equals \code{vm_yld}. Both are weighted with the 1995 cropping pattern held fixed.
+}
+\section{Calibrated input-data yield variables}{
 \tabular{lll}{
    Name \tab Unit \tab Meta \cr
-   Productivity|Yield (after calibration) \tab t DM/ha \tab Potential crop yields after calibration \cr
-   Productivity|Yield (after calibration)|+|Cereals \tab t DM/ha \tab Calibrated cereal yields \cr
-   Productivity|Yield (including tau) \tab t DM/ha \tab Potential yields including tau factor \cr
+   Productivity|Yields|Input data|Calibrated \tab t DM/ha \tab Potential crop yields after calibration, before technological change \cr
+   Productivity|Yields|Input data|Calibrated|+|Cereals \tab t DM/ha \tab Calibrated cereal yields \cr
+   Productivity|Yields|Input data|Calibrated|Including technological change \tab t DM/ha \tab Calibrated potential yields with the tau factor applied (equals vm_yld) \cr
 }
 }
 

--- a/man/reportYieldsCropRaw.Rd
+++ b/man/reportYieldsCropRaw.Rd
@@ -14,16 +14,20 @@ reportYieldsCropRaw(gdx, detail = FALSE, level = "regglo")
 \item{level}{aggregation level of returned data ("regglo" by default)}
 }
 \value{
-yield as MAgPIE object (Mt DM/ha)
+yield as MAgPIE object (t DM/ha)
 }
 \description{
 reports potential yields before calibration
 }
-\section{Raw yield variables}{
+\details{
+Uncalibrated potential yields as they come from the crop model, before management
+calibration and technological change. Weighted with the 1995 cropping pattern held fixed.
+}
+\section{Uncalibrated input-data yield variables}{
 \tabular{lll}{
    Name \tab Unit \tab Meta \cr
-   Productivity|Yield (before calibration) \tab t DM/ha \tab Potential crop yields before calibration \cr
-   Productivity|Yield (before calibration)|+|Cereals \tab t DM/ha \tab Uncalibrated cereal yields \cr
+   Productivity|Yields|Input data|Uncalibrated \tab t DM/ha \tab Potential crop yields before calibration \cr
+   Productivity|Yields|Input data|Uncalibrated|+|Cereals \tab t DM/ha \tab Uncalibrated cereal yields \cr
 }
 }
 


### PR DESCRIPTION
Restructures the yield reporting variables to separate the realized-yield indicators from the
crop-model inputs, as agreed with @FelicitasBeier, Kristine Karstens, Edna Molina Bacca and
Florian Humpenoeder.

| old | new |
|---|---|
| `Productivity\|Yield` | `Productivity\|Yields\|Yield by physical area` |
| `Productivity\|Yield by harvested area` | `Productivity\|Yields\|Yield by harvested area` |
| `Productivity\|Yield (before calibration)` | `Productivity\|Yields\|Input data\|Uncalibrated` |
| `Productivity\|Yield (after calibration)` | `Productivity\|Yields\|Input data\|Calibrated` |
| `Productivity\|Yield (including tau)` | `Productivity\|Yields\|Input data\|Calibrated\|Including technological change` |

Two variables share the old stem and are **not** renamed:
`Productivity|Yield-increasing technological change crops`, and `…managed pastures` (removed
from magpie4 on 2026-01-16, `127ab4e0`, but still present in archived `.mif` files). The
anchored `Productivity|Yield|*` rename rule protects both; an unanchored `Productivity|Yield*`
would swallow them.

### One deviation from what was agreed

The tau-inclusive variable is nested — `…|Calibrated|Including technological change` — rather
than the flat `…|Calibrated and including technological change`. A `|` in place of " and ",
making it a child of `Calibrated` instead of a same-prefixed sibling. Confirmed with Felicitas
Beier (2026-08-15). Happy to flip to the flat form; it is one line in each repo.

### Also in this PR

- `YieldsCropRaw`'s documentation said it reads calibrated yields. It reads uncalibrated
  `f14_yields`.
- `@return` units `Mt DM/ha` → `t DM/ha` in three report functions. The model declares
  `tDM per ha per yr`, and these functions already emit every name with a `(t DM/ha)` suffix.
- The `@section` tables listed nine variables carrying `+`/`++` markers, plus an
  `Irrigated`/`Rainfed` branch, that `reportYields` does not emit. Replaced with the set it
  actually emits, checked against a capture.
- Notes that the realized and input-data variables use different area weights, so the ratio
  between them is not a clean yield gap.

### Merged `master` (2026-08-18)

This branch has merged `upstream/master` at `57bcf6a7`, which brings in the new fallow
implementation. That merge also resolves the `subscript out of bounds` previously listed here
under Known-not-fixed: `croparea()` gained a `physical` argument and now applies the
multicropping ratio before aggregation, so `reportYields(physical = FALSE, level = "glo")`
works. The fix is upstream's, not this PR's — an earlier commit here patched the same crash
independently and was dropped in favour of it.

Re-verified after the merge, with both arms on `57bcf6a7`: 378 names map exactly, all 88452
values bit-identical, 12/12 `level` x `physical` x `detail` combinations run on two different
runs, and `glo` agrees with the `GLO` row of `regglo` to 1e-14.

### Verification

Against a real gdx (`yields: managementcalib_aug19`, `tc: endo_jan22`, rev4.131) at
`level = "regglo"`, `detail = TRUE`: all 378 names map exactly through the rename, **all 88452
values bit-identical**, no old names remain, both tech-change variables untouched, and the
prefix-safety invariant goes 302 → 0.

Re-derived independently from fresh captures at `upstream/master` and at this branch, with a
mutation-tested comparison harness (6/6), then widened across `level` × `detail` × `physical`:
224748 values bit-identical, 0 name mismatches, over the 22 combinations that run.

### Downstream

Companion PRs in **piamInterfaces**, **mrvalidation** (otherwise every yield validation panel
silently loses its history), **magpie**, and **m4fsdp** (selects the legacy spelling in 10
places; without it the FSDP yield panels stay empty).

Version bumped `minor` — say the word if a reported-variable rename should be `major`.

### Known-not-fixed

- `inst/extdata/variablemappingBEST.csv`: 8 of the 16 renamed rows carry `+` markers and so
  name variables that are not emitted. They went dead on 2024-02-26 along with `peatland.R`.
  The file is consumed by `scripts/output/projects/BEST_merge_report.R` in the **magpie** repo.
